### PR TITLE
GitHub Packagesにreleaseを行うWorkflowを追加

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,37 @@
+name: npm publish
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: |
+          npm ci
+          npm run build
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com/
+          scope: '@nekochans'
+      - run: |
+          npm ci
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/5

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/5 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

なし

# 変更点概要

GitHub Packagesに反映を行うWorkflowを追加。

トリガーはリリースページが作成され公開されたタイミングになっている。

# レビュアーに重点的にチェックして欲しい点

なし

# 補足情報

一旦packageがnpmでインストール出来て正常動作するところまで進めたいのでレビューなしでマージする。