### PR TITLE
npm publish 実行時にpackageの中身が空になってしまっていたので修正

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,6 +32,7 @@ jobs:
           scope: '@nekochans'
       - run: |
           npm ci
+          npm run build
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/5

# Done の定義

- npm publish 実行時にBuildされたソースコードが反映されるようになっている事

# スクリーンショット or Storybook の URL

なし

# 変更点概要

npm publish 実行時にpackageの中身が空になってしまっていたので、buildを実行するように修正

# レビュアーに重点的にチェックして欲しい点

なし

# 補足情報

一旦packageがnpmでインストール出来て正常動作するところまで進めたいのでレビューなしでマージする。