### PR TITLE
ChromaticでStorybookをデプロイするWorkflowを追加

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,21 @@
+name: chromatic
+
+on: push
+
+jobs:
+  chromatic-deployment:
+    name: Deploy Storybook to chromatic
+    runs-on: ubuntu-latest
+    timeout-minutes: 7
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: npm ci
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 [![ci](https://github.com/nekochans/lgtm-cat-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/nekochans/lgtm-cat-ui/actions/workflows/ci.yml)
 [![npm publish](https://github.com/nekochans/lgtm-cat-ui/actions/workflows/npm-publish.yml/badge.svg)](https://github.com/nekochans/lgtm-cat-ui/actions/workflows/npm-publish.yml)
+[![chromatic](https://github.com/nekochans/lgtm-cat-ui/actions/workflows/chromatic.yml/badge.svg)](https://github.com/nekochans/lgtm-cat-ui/actions/workflows/chromatic.yml)
 
 https://lgtmeow.com の UIComponent を管理する為の package


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/3

# Done の定義

- コミット毎にChromatic上にStorybookがデプロイされるようになっている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-fcdptyqbnx.chromatic.com/

# 変更点概要

GitHubActionsでコミット毎にChromatic上にStorybookがデプロイされるように対応した。

手順としては下記の記事にまとめた通り。

https://zenn.dev/keitakn/articles/storybook-deploy-to-chromatic#github-actions-%E3%81%A7-chromatic%E3%81%B8%E3%81%AE%E3%83%87%E3%83%97%E3%83%AD%E3%82%A4%E3%82%92%E8%87%AA%E5%8B%95%E5%8C%96%E3%81%99%E3%82%8B

# レビュアーに重点的にチェックして欲しい点

なし

# 補足情報

一旦packageがnpmでインストール出来て正常動作するところまで進めたいのでレビューなしでマージする。