### PR TITLE
新デザインのFooterComponentを取り込み

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import '@fontsource/roboto';
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "webpack": "^5.72.0"
       },
       "peerDependencies": {
+        "@fontsource/roboto": "^4.5.7",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "styled-components": "^5.3.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.17.10",
+        "@fontsource/roboto": "^4.5.7",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-image": "^2.1.1",
         "@rollup/plugin-node-resolve": "^13.2.1",
@@ -2206,6 +2207,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.7.tgz",
+      "integrity": "sha512-m57UMER23Mk6Drg9OjtHW1Y+0KPGyZfE5XJoPTOsLARLar6013kJj4X2HICt+iFLJqIgTahA/QAvSn9lwF1EEw==",
+      "dev": true
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -33416,6 +33423,12 @@
         }
       }
     },
+    "@fontsource/roboto": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.7.tgz",
+      "integrity": "sha512-m57UMER23Mk6Drg9OjtHW1Y+0KPGyZfE5XJoPTOsLARLar6013kJj4X2HICt+iFLJqIgTahA/QAvSn9lwF1EEw==",
+      "dev": true
+    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -34717,7 +34730,8 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -36301,13 +36315,15 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-extract-imports": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -38972,13 +38988,15 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-extract-imports": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -40466,13 +40484,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -40546,13 +40566,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -42988,7 +43010,8 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
       "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-functions-list": {
       "version": "3.0.1",
@@ -43158,7 +43181,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
       "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -44208,13 +44232,15 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
       "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -44492,13 +44518,15 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
       "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-promise": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
       "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.30.0",
@@ -44547,7 +44575,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
       "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-storybook": {
       "version": "0.5.12",
@@ -48368,7 +48397,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -49512,7 +49542,8 @@
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
           "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -51486,25 +51517,29 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
       "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
       "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
       "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
       "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-flexbugs-fixes": {
       "version": "4.2.1",
@@ -51658,13 +51693,15 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-extract-imports": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -51790,7 +51827,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
       "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -51905,7 +51943,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-selector-parser": {
       "version": "6.0.10",
@@ -51921,7 +51960,8 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
       "integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-svgo": {
       "version": "5.1.0",
@@ -51937,7 +51977,8 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-unique-selectors": {
       "version": "5.1.1",
@@ -52317,7 +52358,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
       "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-dom": {
       "version": "18.1.0",
@@ -52358,7 +52400,8 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
       "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-inspector": {
       "version": "5.1.1",
@@ -52983,7 +53026,8 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
       "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -54506,7 +54550,8 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
       "integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylelint-config-recess-order": {
       "version": "3.0.0",
@@ -54521,13 +54566,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
       "integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylelint-config-smarthr": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stylelint-config-smarthr/-/stylelint-config-smarthr-1.0.2.tgz",
       "integrity": "sha512-QDp72aN2QiChBBeHADHat+MhoFl5NtMCsGnTeE+nFH/Cd8Bw8Y7xqTTwghBOi72J7+Dzcuu4UflZvVt8+AyLOw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylelint-config-standard": {
       "version": "25.0.0",
@@ -56107,7 +56154,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "webpack-hot-middleware": {
       "version": "2.25.1",
@@ -56298,7 +56346,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
       "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "x-default-browser": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "peerDependencies": {
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^5.3.5",
+    "@fontsource/roboto": "^4.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/nekochans/lgtm-cat-ui#readme",
   "devDependencies": {
     "@babel/core": "^7.17.10",
+    "@fontsource/roboto": "^4.5.7",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-image": "^2.1.1",
     "@rollup/plugin-node-resolve": "^13.2.1",

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Footer } from './';
 
 import type { ComponentStoryObj, Meta } from '@storybook/react';
@@ -9,4 +11,28 @@ export default {
 
 type Story = ComponentStoryObj<typeof Footer>;
 
-export const Default: Story = {};
+const termsUrl = 'https://lgtmeow.com/terms';
+
+const privacyUrl = 'https://lgtmeow.com/privacy';
+
+export const ViewInJapanese: Story = {
+  args: {
+    terms: {
+      linkText: <a href={termsUrl}>利用規約</a>,
+    },
+    privacy: {
+      linkText: <a href={privacyUrl}>プライバシーポリシー</a>,
+    },
+  },
+};
+
+export const ViewInEnglish: Story = {
+  args: {
+    terms: {
+      linkText: <a href={termsUrl}>Terms of Use</a>,
+    },
+    privacy: {
+      linkText: <a href={privacyUrl}>Privacy Policy</a>,
+    },
+  },
+};

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,0 +1,12 @@
+import { Footer } from './';
+
+import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+export default {
+  title: 'src/components/Footer/Footer.tsx',
+  component: Footer,
+} as Meta<typeof Footer>;
+
+type Story = ComponentStoryObj<typeof Footer>;
+
+export const Default: Story = {};

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -52,11 +52,22 @@ const LowerSectionText = styled.div`
   color: #43281e;
 `;
 
-export const Footer: React.FC = () => (
+type Props = {
+  terms: {
+    linkText: React.ReactNode;
+  };
+  privacy: {
+    linkText: React.ReactNode;
+  };
+};
+
+export const Footer: React.FC<Props> = ({ terms, privacy }) => (
   <StyledFooter>
     <UpperSection>
       {/* eslint-disable no-irregular-whitespace */}
-      <UpperSectionText>利用規約　/　プライバシーポリシー</UpperSectionText>
+      <UpperSectionText>
+        {terms.linkText}　/　{privacy.linkText}
+      </UpperSectionText>
     </UpperSection>
     <LowerSection>
       <LowerSectionText>Copyright (c) nekochans</LowerSectionText>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+import '@fontsource/roboto';
+
+const StyledFooter = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const UpperSection = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 605px 20px;
+  background: #fffcf6;
+`;
+
+const UpperSectionText = styled.div`
+  width: 230px;
+  height: 28px;
+  font-family: Roboto;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 28px;
+  color: #43281e;
+  text-align: center;
+  text-decoration-line: underline;
+`;
+
+const LowerSection = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 644px;
+  background: #f2ebdf;
+`;
+
+const LowerSectionText = styled.div`
+  width: 152px;
+  height: 28px;
+  font-family: Roboto;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 28px;
+  color: #43281e;
+`;
+
+export const Footer: React.FC = () => (
+  <StyledFooter>
+    <UpperSection>
+      {/* eslint-disable no-irregular-whitespace */}
+      <UpperSectionText>利用規約　/　プライバシーポリシー</UpperSectionText>
+    </UpperSection>
+    <LowerSection>
+      <LowerSectionText>Copyright (c) nekochans</LowerSectionText>
+    </LowerSection>
+  </StyledFooter>
+);

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import '@fontsource/roboto';
 
 const StyledFooter = styled.div`
   position: relative;

--- a/src/components/Footer/index.ts
+++ b/src/components/Footer/index.ts
@@ -1,0 +1,1 @@
+export { Footer } from './Footer';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export { SampleButton } from './SampleButton';
 export { SampleIcon } from './SampleIcon';
+export { Footer } from './Footer';

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -9,5 +9,9 @@ module.exports = {
   rules: {
     'function-whitespace-after': null,
     'function-no-unknown': null,
+    'font-family-no-missing-generic-family-keyword': [
+      true,
+      { ignoreFontFamilies: 'Roboto' },
+    ],
   },
 };


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/25

# Done の定義

- Figma上のFooterComponentが取り込まれている事

# スクリーンショット or Storybook の URL

## 日本語表記

https://62729802bbcc7d004a663d4c-oycbjnjwwm.chromatic.com/?path=/story/src-components-footer-footer-tsx--view-in-japanese

## 英語表記

https://62729802bbcc7d004a663d4c-oycbjnjwwm.chromatic.com/?path=/story/src-components-footer-footer-tsx--view-in-english

# 変更点概要

Figma上に存在するFooterComponentのデザインを利用してFooterComponentを作成。

フォントに `@fontsource/roboto` を利用しているので `peerDependencies` に追加。

Packageを利用する側も `@fontsource/roboto` をインストールする必要がある。

本来であればフォントもBuildする予定だったが、rollupでのBuildが上手くいかなかったのでこの形にしてある。

# レビュアーに重点的にチェックして欲しい点

Storybook上のデザインとFigmaを比較して確認してもらえると:pray:

# 補足情報

このPRは https://github.com/nekochans/lgtm-cat-ui/pull/24 に依存している。

フォントのBuildが出来るようにしないと一瞬ブラウザDefaultのフォントが表示されてしまうので https://github.com/nekochans/lgtm-cat-ui/issues/28 で対応を行う。