### PR TITLE
GitHubログイン用のButtonComponentを追加

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,7 +1,3 @@
-<link
-  href="https://unpkg.com/modern-css-reset/dist/reset.min.css"
-  rel="stylesheet"
-/>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,7 @@
+<link
+  href="https://unpkg.com/modern-css-reset/dist/reset.min.css"
+  rel="stylesheet"
+/>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import 'ress/ress.css';
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-icons": "^4.3.1",
+        "ress": "^5.0.2",
         "rollup": "^2.71.1",
         "rollup-plugin-dts": "^4.2.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -72,6 +73,7 @@
         "webpack": "^5.72.0"
       },
       "peerDependencies": {
+        "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "styled-components": "^5.3.5"
@@ -27780,6 +27782,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/ress": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ress/-/ress-5.0.2.tgz",
+      "integrity": "sha512-oHBtOWo/Uc8SzQMbQNIKTcgi8wKmAs7IlNlRywmXudbOtF+c27FlOIq7tnwLDVcTywe6JXYo1pDXHO6kABwNYA==",
+      "dev": true
+    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -53372,6 +53380,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
+      "dev": true
+    },
+    "ress": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ress/-/ress-5.0.2.tgz",
+      "integrity": "sha512-oHBtOWo/Uc8SzQMbQNIKTcgi8wKmAs7IlNlRywmXudbOtF+c27FlOIq7tnwLDVcTywe6JXYo1pDXHO6kABwNYA==",
       "dev": true
     },
     "ret": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-icons": "^4.3.1",
+    "ress": "^5.0.2",
     "rollup": "^2.71.1",
     "rollup-plugin-dts": "^4.2.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -97,9 +98,9 @@
     "webpack": "^5.72.0"
   },
   "peerDependencies": {
+    "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "styled-components": "^5.3.5",
-    "next": "^12.1.6"
+    "styled-components": "^5.3.5"
   }
 }

--- a/src/components/GitHubLoginButton/GitHubLoginButton.stories.tsx
+++ b/src/components/GitHubLoginButton/GitHubLoginButton.stories.tsx
@@ -1,0 +1,12 @@
+import { GitHubLoginButton } from './GitHubLoginButton';
+
+import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+export default {
+  title: 'src/components/GitHubLoginButton/GitHubLoginButton.tsx',
+  component: GitHubLoginButton,
+} as Meta<typeof GitHubLoginButton>;
+
+type Story = ComponentStoryObj<typeof GitHubLoginButton>;
+
+export const Default: Story = {};

--- a/src/components/GitHubLoginButton/GitHubLoginButton.tsx
+++ b/src/components/GitHubLoginButton/GitHubLoginButton.tsx
@@ -3,14 +3,14 @@ import { FaGithub } from 'react-icons/fa';
 import styled from 'styled-components';
 
 const StyledGitHubLoginButton = styled.button`
-  position: absolute;
-  top: 20px;
-  left: 20px;
   display: flex;
+  flex: none;
   flex-direction: row;
+  flex-grow: 0;
   gap: 10px;
   align-items: center;
-  width: 117px;
+  order: 0;
+  width: 116px;
   height: 36px;
   padding: 4px 20px;
   background: #eb7c06;
@@ -22,18 +22,29 @@ const Text = styled.div`
   flex-grow: 0;
   order: 1;
   width: 40px;
-  height: 28px;
+  height: 16px;
   font-family: Roboto, sans-serif;
   font-size: 16px;
   font-style: normal;
   font-weight: 400;
-  line-height: 28px;
-  color: #f2ede4;
+  line-height: 16px;
+  color: #f2ebdf;
 `;
+
+const faGithubStyle = {
+  fontStyle: 'normal',
+  fontWeight: 400,
+  width: '26px',
+  height: '26px',
+  color: '#f2ebdf',
+  flex: 'none',
+  order: 1,
+  flexGrow: 0,
+};
 
 export const GitHubLoginButton: React.FC = () => (
   <StyledGitHubLoginButton>
-    <FaGithub style={{ width: '27px', height: '26.33px', color: '#fff' }} />
+    <FaGithub style={faGithubStyle} />
     <Text>Login</Text>
   </StyledGitHubLoginButton>
 );

--- a/src/components/GitHubLoginButton/GitHubLoginButton.tsx
+++ b/src/components/GitHubLoginButton/GitHubLoginButton.tsx
@@ -33,7 +33,7 @@ const Text = styled.div`
 
 export const GitHubLoginButton: React.FC = () => (
   <StyledGitHubLoginButton>
-    <FaGithub style={{ width: '27px', height: '26.33px' }} />
+    <FaGithub style={{ width: '27px', height: '26.33px', color: '#fff' }} />
     <Text>Login</Text>
   </StyledGitHubLoginButton>
 );

--- a/src/components/GitHubLoginButton/GitHubLoginButton.tsx
+++ b/src/components/GitHubLoginButton/GitHubLoginButton.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { FaGithub } from 'react-icons/fa';
+import styled from 'styled-components';
+
+const StyledGitHubLoginButton = styled.button`
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  align-items: center;
+  width: 117px;
+  height: 36px;
+  padding: 4px 20px;
+  background: #eb7c06;
+  border-radius: 4px;
+`;
+
+const Text = styled.div`
+  flex: none;
+  flex-grow: 0;
+  order: 1;
+  width: 40px;
+  height: 28px;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 28px;
+  color: #f2ede4;
+`;
+
+export const GitHubLoginButton: React.FC = () => (
+  <StyledGitHubLoginButton>
+    <FaGithub style={{ width: '27px', height: '26.33px' }} />
+    <Text>Login</Text>
+  </StyledGitHubLoginButton>
+);

--- a/src/components/GitHubLoginButton/index.ts
+++ b/src/components/GitHubLoginButton/index.ts
@@ -1,0 +1,1 @@
+export { GitHubLoginButton } from './GitHubLoginButton';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/32

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/32 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-qrgkrvxzjl.chromatic.com/?path=/story/src-components-githubloginbutton-githubloginbutton-tsx--default

# 変更点概要

Header内で利用されているのでGitHubログイン用のButtonComponentを追加しました。

GitHubのアイコンは https://react-icons.github.io/react-icons/icons?name=fa の物を利用。

また一部CSSが崩れていたのでリセットCSSである `ress` を導入した。

# レビュアーに重点的にチェックして欲しい点

インラインコメントを確認してもらえると:pray:

# 補足情報

特になし