### PR TITLE
言語設定のデザインを調整、現在選択している言語をStateで記憶するように変更

### DIFF
--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -9,4 +9,14 @@ export default {
 
 type Story = ComponentStoryObj<typeof Header>;
 
-export const Default: Story = {};
+export const LanguageJa: Story = {
+  args: {
+    language: 'ja',
+  },
+};
+
+export const LanguageEn: Story = {
+  args: {
+    language: 'en',
+  },
+};

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import { FaBars } from 'react-icons/fa';
 import styled from 'styled-components';
 
 import { LanguageButton } from './LanguageButton';
-import { LanguageMenu } from './LanguageMenu';
+import { LanguageMenu, Props as LanguageMenuProps } from './LanguageMenu';
 
 const Wrapper = styled.div`
   background: #e9e2d7;
@@ -48,7 +48,9 @@ const faBarsStyle = {
   flexGrow: 0,
 };
 
-export const Header: React.FC = () => {
+export type Props = LanguageMenuProps;
+
+export const Header: React.FC<Props> = ({ language }) => {
   const [isMenuDisplayed, setIsMenuDisplayed] = React.useState<boolean>(false);
 
   const handleOnClickLanguageButton = () => {
@@ -62,7 +64,7 @@ export const Header: React.FC = () => {
           <FaBars style={faBarsStyle} />
           <Title>LGTMeow</Title>
           <LanguageButton onClick={handleOnClickLanguageButton} />
-          {isMenuDisplayed ? <LanguageMenu /> : ''}
+          {isMenuDisplayed ? <LanguageMenu language={language} /> : ''}
         </StyledHeader>
       </Wrapper>
     </>

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -34,9 +34,11 @@ const EnText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
+  height: 19px;
+  font-family: Roboto, sans-serif;
   font-size: 16px;
   font-style: normal;
-  font-weight: 900;
+  font-weight: 400;
   line-height: 19px;
   color: #faf9f7;
 `;
@@ -54,26 +56,46 @@ const JaText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 2;
+  height: 19px;
   font-family: Roboto, sans-serif;
   font-size: 16px;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 900;
   line-height: 19px;
   color: #faf9f7;
 `;
 
-export const LanguageMenu: React.FC = () => (
-  <StyledLanguageMenu>
-    <Wrapper>
-      <EnText>
-        <FaAngleRight />
-        English
-      </EnText>
-      <Separator />
-      <JaText>
-        <FaAngleRight />
-        日本語
-      </JaText>
-    </Wrapper>
-  </StyledLanguageMenu>
-);
+type Language = 'ja' | 'en';
+
+export type Props = {
+  language: Language;
+};
+
+export const LanguageMenu: React.FC<Props> = ({ language }) => {
+  const [selectedLanguage, setSelectedLanguage] =
+    React.useState<Language>(language);
+
+  const onClickEn = () => {
+    setSelectedLanguage('en');
+  };
+
+  const onClickJa = () => {
+    setSelectedLanguage('ja');
+  };
+
+  return (
+    <StyledLanguageMenu>
+      <Wrapper>
+        <EnText onClick={onClickEn}>
+          {selectedLanguage === 'en' ? <FaAngleRight /> : ''}
+          English
+        </EnText>
+        <Separator />
+        <JaText onClick={onClickJa}>
+          {selectedLanguage === 'ja' ? <FaAngleRight /> : ''}
+          日本語
+        </JaText>
+      </Wrapper>
+    </StyledLanguageMenu>
+  );
+};

--- a/src/components/Header/index.ts
+++ b/src/components/Header/index.ts
@@ -1,1 +1,1 @@
-export { Header } from './Header';
+export { Header, Props } from './Header';

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -55,6 +55,7 @@ export const ViewInJapanese: Story = {
       text: jpPrivacyText,
       link: privacyUrl,
     },
+    language: 'ja',
     children: <JpContents />,
   },
 };
@@ -69,6 +70,7 @@ export const ViewInEnglish: Story = {
       text: enPrivacyText,
       link: privacyUrl,
     },
+    language: 'en',
     children: <EnContents />,
   },
 };
@@ -84,6 +86,7 @@ export const ViewInJapaneseWithNextLink: Story = {
       link: privacyPath,
     },
     useNextLink: true,
+    language: 'ja',
     children: <JpContents />,
   },
 };
@@ -99,6 +102,7 @@ export const ViewInEnglishWithNextLink: Story = {
       link: privacyPath,
     },
     useNextLink: true,
+    language: 'en',
     children: <EnContents />,
   },
 };

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -2,24 +2,26 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Footer, Props as FooterProps } from '../Footer';
-import { Header } from '../Header';
+import { Header, Props as HeaderProps } from '../Header';
 
 const Wrapper = styled.div`
   position: relative;
 `;
 
-type Props = FooterProps & {
-  children: React.ReactNode;
-};
+type Props = FooterProps &
+  HeaderProps & {
+    children: React.ReactNode;
+  };
 
 export const Layout: React.FC<Props> = ({
   terms,
   privacy,
   useNextLink,
+  language,
   children,
 }) => (
   <Wrapper>
-    <Header />
+    <Header language={language} />
     {children}
     <Footer terms={terms} privacy={privacy} useNextLink={useNextLink} />
   </Wrapper>


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/26

# Done の定義

- 選択している言語情報をStateで記憶出来るようになっている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-ejfmfpxmet.chromatic.com/?path=/story/src-components-header-header-tsx--language-ja

# 変更点概要

言語情報を記録して選択している言語のにみ→のアイコンをつけるように変更。

現時点ではメニューを閉じてしまうと言語情報が失われてしまうので別PRでState管理の仕組みを導入して解決する。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
