### PR TITLE
LayoutContainerの実装

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,6 +5,7 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     '@storybook/addon-a11y',
+    'storybook-addon-next',
     {
       name: '@storybook/addon-postcss',
       options: {

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  images: {
+    domains: ['lgtm-images.lgtmeow.com', 'stg-lgtm-images.lgtmeow.com'],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "ts-jest": "^27.1.4",
         "tslib": "^2.4.0",
         "typescript": "^4.6.4",
+        "valtio": "^1.6.1",
         "webpack": "^5.72.0"
       },
       "peerDependencies": {
@@ -26728,6 +26729,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-compare": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.1.0.tgz",
+      "integrity": "sha512-wapJ3h/w8fRSyPEG0y2WMV+tf9xwvj3nxM6aHVuPEOwKs/t5xLSKZb44ubNTiqq2T6lmEMHEWGMTaU2L6ddaFA==",
+      "dev": true
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -31212,6 +31219,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -31311,6 +31327,47 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/valtio": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.6.1.tgz",
+      "integrity": "sha512-caSZhnKNHbsUNQSftEzIeDKFP9Wcmj2c1hrCLWA0vA4eUBu6vxqEPs/cm0ln8umF5L1xbQGppopt79xxELmkAg==",
+      "dev": true,
+      "dependencies": {
+        "proxy-compare": "2.1.0",
+        "use-sync-external-store": "1.1.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@babel/helper-module-imports": ">=7.12",
+        "@babel/types": ">=7.13",
+        "aslemammad-vite-plugin-macro": ">=1.0.0-alpha.1",
+        "babel-plugin-macros": ">=3.0",
+        "react": ">=16.8",
+        "vite": ">=2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/helper-module-imports": {
+          "optional": true
+        },
+        "@babel/types": {
+          "optional": true
+        },
+        "aslemammad-vite-plugin-macro": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vary": {
@@ -52564,6 +52621,12 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxy-compare": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.1.0.tgz",
+      "integrity": "sha512-wapJ3h/w8fRSyPEG0y2WMV+tf9xwvj3nxM6aHVuPEOwKs/t5xLSKZb44ubNTiqq2T6lmEMHEWGMTaU2L6ddaFA==",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -56060,6 +56123,13 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "dev": true,
+      "requires": {}
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -56150,6 +56220,16 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "valtio": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.6.1.tgz",
+      "integrity": "sha512-caSZhnKNHbsUNQSftEzIeDKFP9Wcmj2c1hrCLWA0vA4eUBu6vxqEPs/cm0ln8umF5L1xbQGppopt79xxELmkAg==",
+      "dev": true,
+      "requires": {
+        "proxy-compare": "2.1.0",
+        "use-sync-external-store": "1.1.0"
       }
     },
     "vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "rollup-plugin-dts": "^4.2.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
+        "storybook-addon-next": "^1.6.6",
         "styled-components": "^5.3.5",
         "stylelint": "^14.8.2",
         "stylelint-config-prettier": "^9.0.3",
@@ -11503,6 +11504,19 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/adjust-sourcemap-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "regex-parser": "^2.2.11"
+      },
+      "engines": {
+        "node": ">=8.9"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -19131,6 +19145,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.1.tgz",
+      "integrity": "sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==",
+      "dev": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/import-cwd": {
@@ -26841,6 +26870,15 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -27392,6 +27430,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regex-parser": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
+      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
+      "dev": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -27779,6 +27823,22 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
+    },
+    "node_modules/resolve-url-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
+      "dev": true,
+      "dependencies": {
+        "adjust-sourcemap-loader": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "loader-utils": "^2.0.0",
+        "postcss": "^8.2.14",
+        "source-map": "0.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/resolve.exports": {
       "version": "1.1.0",
@@ -28393,6 +28453,44 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/sass-loader": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
+      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
+      "dev": true,
+      "dependencies": {
+        "klona": "^2.0.4",
+        "neo-async": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "sass": "^1.3.0",
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        }
       }
     },
     "node_modules/saxes": {
@@ -29247,6 +29345,96 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.13.2.tgz",
       "integrity": "sha512-CMtO2Uneg3SAz/d6fZ/6qbqqQHi2ynq6/KzMD/26gTkiEShCcpqFfTHgOxsE0egAq6SX3FmN4CeSqn8BzXQkJg==",
       "dev": true
+    },
+    "node_modules/storybook-addon-next": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/storybook-addon-next/-/storybook-addon-next-1.6.6.tgz",
+      "integrity": "sha512-HbGY7DM+qW925rgladudF2PJK+Iq06bRTPseGn6qXnIgC9L/FvBzI1UvDcguYMYWUOzGCbFl11DpHcU/pE1KkQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.4.10",
+        "image-size": "^1.0.0",
+        "loader-utils": "^3.2.0",
+        "postcss-loader": "^6.2.1",
+        "resolve-url-loader": "^5.0.0",
+        "sass-loader": "^12.4.0",
+        "semver": "^7.3.5",
+        "tsconfig-paths": "^4.0.0",
+        "tsconfig-paths-webpack-plugin": "^3.5.2"
+      },
+      "peerDependencies": {
+        "@storybook/addon-actions": "^6.0.0",
+        "@storybook/addons": "^6.0.0",
+        "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/storybook-addon-next/node_modules/loader-utils": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
+      "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/storybook-addon-next/node_modules/postcss-loader": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
+      "integrity": "sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^7.0.0",
+        "klona": "^2.0.5",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "postcss": "^7.0.0 || ^8.0.1",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/storybook-addon-next/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/storybook-addon-next/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/storybook-addon-next/node_modules/tsconfig-paths": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
+      "integrity": "sha512-SLBg2GBKlR6bVtMgJJlud/o3waplKtL7skmLkExomIiaAtLGtVsoXIqP3SYdjbcH9lq/KVv7pMZeCBpLYOit6Q==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
     },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
@@ -30650,6 +30838,87 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz",
+      "integrity": "sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^3.9.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
@@ -40941,6 +41210,16 @@
       "integrity": "sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig==",
       "dev": true
     },
+    "adjust-sourcemap-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "regex-parser": "^2.2.11"
+      }
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -46886,6 +47165,15 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
+    "image-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.1.tgz",
+      "integrity": "sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==",
+      "dev": true,
+      "requires": {
+        "queue": "6.0.2"
+      }
+    },
     "import-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
@@ -52721,6 +53009,15 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.3"
+      }
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -53145,6 +53442,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regex-parser": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
+      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
+      "dev": true
+    },
     "regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -53438,6 +53741,19 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "resolve-url-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
+      "dev": true,
+      "requires": {
+        "adjust-sourcemap-loader": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "loader-utils": "^2.0.0",
+        "postcss": "^8.2.14",
+        "source-map": "0.6.1"
+      }
     },
     "resolve.exports": {
       "version": "1.1.0",
@@ -53912,6 +54228,16 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "sass-loader": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
+      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
+      "dev": true,
+      "requires": {
+        "klona": "^2.0.4",
+        "neo-async": "^2.6.2"
       }
     },
     "saxes": {
@@ -54627,6 +54953,68 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.13.2.tgz",
       "integrity": "sha512-CMtO2Uneg3SAz/d6fZ/6qbqqQHi2ynq6/KzMD/26gTkiEShCcpqFfTHgOxsE0egAq6SX3FmN4CeSqn8BzXQkJg==",
       "dev": true
+    },
+    "storybook-addon-next": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/storybook-addon-next/-/storybook-addon-next-1.6.6.tgz",
+      "integrity": "sha512-HbGY7DM+qW925rgladudF2PJK+Iq06bRTPseGn6qXnIgC9L/FvBzI1UvDcguYMYWUOzGCbFl11DpHcU/pE1KkQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.4.10",
+        "image-size": "^1.0.0",
+        "loader-utils": "^3.2.0",
+        "postcss-loader": "^6.2.1",
+        "resolve-url-loader": "^5.0.0",
+        "sass-loader": "^12.4.0",
+        "semver": "^7.3.5",
+        "tsconfig-paths": "^4.0.0",
+        "tsconfig-paths-webpack-plugin": "^3.5.2"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
+          "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==",
+          "dev": true
+        },
+        "postcss-loader": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
+          "integrity": "sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==",
+          "dev": true,
+          "requires": {
+            "cosmiconfig": "^7.0.0",
+            "klona": "^2.0.5",
+            "semver": "^7.3.5"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "tsconfig-paths": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
+          "integrity": "sha512-SLBg2GBKlR6bVtMgJJlud/o3waplKtL7skmLkExomIiaAtLGtVsoXIqP3SYdjbcH9lq/KVv7pMZeCBpLYOit6Q==",
+          "dev": true,
+          "requires": {
+            "json5": "^2.2.1",
+            "minimist": "^1.2.6",
+            "strip-bom": "^3.0.0"
+          }
+        }
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -55713,6 +56101,68 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
+        }
+      }
+    },
+    "tsconfig-paths-webpack-plugin": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz",
+      "integrity": "sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "ts-jest": "^27.1.4",
     "tslib": "^2.4.0",
     "typescript": "^4.6.4",
+    "valtio": "^1.6.1",
     "webpack": "^5.72.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "rollup-plugin-dts": "^4.2.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
+    "storybook-addon-next": "^1.6.6",
     "styled-components": "^5.3.5",
     "stylelint": "^14.8.2",
     "stylelint-config-prettier": "^9.0.3",

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -48,25 +48,36 @@ const faBarsStyle = {
   flexGrow: 0,
 };
 
-export type Props = LanguageMenuProps;
-
-export const Header: React.FC<Props> = ({ language }) => {
-  const [isMenuDisplayed, setIsMenuDisplayed] = React.useState<boolean>(false);
-
-  const handleOnClickLanguageButton = () => {
-    setIsMenuDisplayed(!isMenuDisplayed);
-  };
-
-  return (
-    <>
-      <Wrapper>
-        <StyledHeader>
-          <FaBars style={faBarsStyle} />
-          <Title>LGTMeow</Title>
-          <LanguageButton onClick={handleOnClickLanguageButton} />
-          {isMenuDisplayed ? <LanguageMenu language={language} /> : ''}
-        </StyledHeader>
-      </Wrapper>
-    </>
-  );
+export type Props = LanguageMenuProps & {
+  isLanguageMenuDisplayed: boolean;
+  onClickLanguageButton: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onClickEn: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onClickJa: (event: React.MouseEvent<HTMLDivElement>) => void;
 };
+
+export const Header: React.FC<Props> = ({
+  language,
+  isLanguageMenuDisplayed,
+  onClickLanguageButton,
+  onClickEn,
+  onClickJa,
+}) => (
+  <>
+    <Wrapper>
+      <StyledHeader>
+        <FaBars style={faBarsStyle} />
+        <Title>LGTMeow</Title>
+        <LanguageButton onClick={onClickLanguageButton} />
+        {isLanguageMenuDisplayed ? (
+          <LanguageMenu
+            language={language}
+            onClickEn={onClickEn}
+            onClickJa={onClickJa}
+          />
+        ) : (
+          ''
+        )}
+      </StyledHeader>
+    </Wrapper>
+  </>
+);

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -51,8 +51,6 @@ const faBarsStyle = {
 export type Props = LanguageMenuProps & {
   isLanguageMenuDisplayed: boolean;
   onClickLanguageButton: (event: React.MouseEvent<HTMLDivElement>) => void;
-  onClickEn: (event: React.MouseEvent<HTMLDivElement>) => void;
-  onClickJa: (event: React.MouseEvent<HTMLDivElement>) => void;
 };
 
 export const Header: React.FC<Props> = ({

--- a/src/components/Header/LanguageButton.tsx
+++ b/src/components/Header/LanguageButton.tsx
@@ -32,7 +32,7 @@ const Text = styled.p`
 `;
 
 type Props = {
-  onClick: () => void;
+  onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
 };
 
 export const LanguageButton: React.FC<Props> = ({ onClick }) => (

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { FaAngleRight } from 'react-icons/fa';
 import styled from 'styled-components';
 
+import { Language } from '../../types/language';
+
 const StyledLanguageMenu = styled.div`
   @media (max-width: 767px) {
     right: 0;
@@ -64,8 +66,6 @@ const JaText = styled.div`
   line-height: 19px;
   color: #faf9f7;
 `;
-
-type Language = 'ja' | 'en';
 
 export type Props = {
   language: Language;

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -69,33 +69,26 @@ type Language = 'ja' | 'en';
 
 export type Props = {
   language: Language;
+  onClickEn: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onClickJa: (event: React.MouseEvent<HTMLDivElement>) => void;
 };
 
-export const LanguageMenu: React.FC<Props> = ({ language }) => {
-  const [selectedLanguage, setSelectedLanguage] =
-    React.useState<Language>(language);
-
-  const onClickEn = () => {
-    setSelectedLanguage('en');
-  };
-
-  const onClickJa = () => {
-    setSelectedLanguage('ja');
-  };
-
-  return (
-    <StyledLanguageMenu>
-      <Wrapper>
-        <EnText onClick={onClickEn}>
-          {selectedLanguage === 'en' ? <FaAngleRight /> : ''}
-          English
-        </EnText>
-        <Separator />
-        <JaText onClick={onClickJa}>
-          {selectedLanguage === 'ja' ? <FaAngleRight /> : ''}
-          日本語
-        </JaText>
-      </Wrapper>
-    </StyledLanguageMenu>
-  );
-};
+export const LanguageMenu: React.FC<Props> = ({
+  language,
+  onClickEn,
+  onClickJa,
+}) => (
+  <StyledLanguageMenu>
+    <Wrapper>
+      <EnText onClick={onClickEn}>
+        {language === 'en' ? <FaAngleRight /> : ''}
+        English
+      </EnText>
+      <Separator />
+      <JaText onClick={onClickJa}>
+        {language === 'ja' ? <FaAngleRight /> : ''}
+        日本語
+      </JaText>
+    </Wrapper>
+  </StyledLanguageMenu>
+);

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -10,6 +10,10 @@ const Wrapper = styled.div`
 
 export type Props = FooterProps &
   HeaderProps & {
+    isLanguageMenuDisplayed: boolean;
+    onClickLanguageButton: (event: React.MouseEvent<HTMLDivElement>) => void;
+    onClickEn: (event: React.MouseEvent<HTMLDivElement>) => void;
+    onClickJa: (event: React.MouseEvent<HTMLDivElement>) => void;
     children: React.ReactNode;
   };
 
@@ -18,10 +22,20 @@ export const Layout: React.FC<Props> = ({
   privacy,
   useNextLink,
   language,
+  isLanguageMenuDisplayed,
+  onClickLanguageButton,
+  onClickEn,
+  onClickJa,
   children,
 }) => (
   <Wrapper>
-    <Header language={language} />
+    <Header
+      language={language}
+      isLanguageMenuDisplayed={isLanguageMenuDisplayed}
+      onClickLanguageButton={onClickLanguageButton}
+      onClickEn={onClickEn}
+      onClickJa={onClickJa}
+    />
     {children}
     <Footer terms={terms} privacy={privacy} useNextLink={useNextLink} />
   </Wrapper>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -8,14 +8,7 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
-export type Props = FooterProps &
-  HeaderProps & {
-    isLanguageMenuDisplayed: boolean;
-    onClickLanguageButton: (event: React.MouseEvent<HTMLDivElement>) => void;
-    onClickEn: (event: React.MouseEvent<HTMLDivElement>) => void;
-    onClickJa: (event: React.MouseEvent<HTMLDivElement>) => void;
-    children: React.ReactNode;
-  };
+export type Props = FooterProps & HeaderProps & { children: React.ReactNode };
 
 export const Layout: React.FC<Props> = ({
   terms,

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -8,7 +8,7 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
-type Props = FooterProps &
+export type Props = FooterProps &
   HeaderProps & {
     children: React.ReactNode;
   };

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,1 +1,1 @@
-export { Layout } from './Layout';
+export { Layout, Props } from './Layout';

--- a/src/containers/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.stories.tsx
@@ -11,24 +11,6 @@ export default {
 
 type Story = ComponentStoryObj<typeof LayoutContainer>;
 
-const termsPath = '/terms';
-
-const privacyPath = '/privacy';
-
-const jpTermsText = '利用規約';
-
-const jpPrivacyText = 'プライバシーポリシー';
-
-const enTermsText = 'Terms of Use';
-
-const enPrivacyText = 'Privacy Policy';
-
-const baseUrl = 'https://lgtmeow.com';
-
-const termsUrl = `${baseUrl}${termsPath}` as const;
-
-const privacyUrl = `${baseUrl}${privacyPath}` as const;
-
 const JpContents: React.FC = () => (
   <>
     <h1>タイトル</h1>
@@ -37,72 +19,16 @@ const JpContents: React.FC = () => (
   </>
 );
 
-const EnContents: React.FC = () => (
-  <>
-    <h1>Title</h1>
-    <h2>SubTitle</h2>
-    <p>Contents</p>
-  </>
-);
-
-export const ViewInJapanese: Story = {
+export const Default: Story = {
   args: {
-    terms: {
-      text: jpTermsText,
-      link: termsUrl,
-    },
-    privacy: {
-      text: jpPrivacyText,
-      link: privacyUrl,
-    },
-    language: 'ja',
+    useNextLink: false,
     children: <JpContents />,
   },
 };
 
-export const ViewInEnglish: Story = {
+export const WithNextLink: Story = {
   args: {
-    terms: {
-      text: enTermsText,
-      link: termsUrl,
-    },
-    privacy: {
-      text: enPrivacyText,
-      link: privacyUrl,
-    },
-    language: 'en',
-    children: <EnContents />,
-  },
-};
-
-export const ViewInJapaneseWithNextLink: Story = {
-  args: {
-    terms: {
-      text: jpTermsText,
-      link: termsPath,
-    },
-    privacy: {
-      text: jpPrivacyText,
-      link: privacyPath,
-    },
     useNextLink: true,
-    language: 'ja',
     children: <JpContents />,
-  },
-};
-
-export const ViewInEnglishWithNextLink: Story = {
-  args: {
-    terms: {
-      text: enTermsText,
-      link: termsPath,
-    },
-    privacy: {
-      text: enPrivacyText,
-      link: privacyPath,
-    },
-    useNextLink: true,
-    language: 'en',
-    children: <EnContents />,
   },
 };

--- a/src/containers/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.stories.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+
+import { LayoutContainer } from './.';
+
+import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+export default {
+  title: 'src/containers/LayoutContainer/LayoutContainer.tsx',
+  component: LayoutContainer,
+} as Meta<typeof LayoutContainer>;
+
+type Story = ComponentStoryObj<typeof LayoutContainer>;
+
+const termsPath = '/terms';
+
+const privacyPath = '/privacy';
+
+const jpTermsText = '利用規約';
+
+const jpPrivacyText = 'プライバシーポリシー';
+
+const enTermsText = 'Terms of Use';
+
+const enPrivacyText = 'Privacy Policy';
+
+const baseUrl = 'https://lgtmeow.com';
+
+const termsUrl = `${baseUrl}${termsPath}` as const;
+
+const privacyUrl = `${baseUrl}${privacyPath}` as const;
+
+const JpContents: React.FC = () => (
+  <>
+    <h1>タイトル</h1>
+    <h2>サブタイトル</h2>
+    <p>コンテンツ</p>
+  </>
+);
+
+const EnContents: React.FC = () => (
+  <>
+    <h1>Title</h1>
+    <h2>SubTitle</h2>
+    <p>Contents</p>
+  </>
+);
+
+export const ViewInJapanese: Story = {
+  args: {
+    terms: {
+      text: jpTermsText,
+      link: termsUrl,
+    },
+    privacy: {
+      text: jpPrivacyText,
+      link: privacyUrl,
+    },
+    language: 'ja',
+    children: <JpContents />,
+  },
+};
+
+export const ViewInEnglish: Story = {
+  args: {
+    terms: {
+      text: enTermsText,
+      link: termsUrl,
+    },
+    privacy: {
+      text: enPrivacyText,
+      link: privacyUrl,
+    },
+    language: 'en',
+    children: <EnContents />,
+  },
+};
+
+export const ViewInJapaneseWithNextLink: Story = {
+  args: {
+    terms: {
+      text: jpTermsText,
+      link: termsPath,
+    },
+    privacy: {
+      text: jpPrivacyText,
+      link: privacyPath,
+    },
+    useNextLink: true,
+    language: 'ja',
+    children: <JpContents />,
+  },
+};
+
+export const ViewInEnglishWithNextLink: Story = {
+  args: {
+    terms: {
+      text: enTermsText,
+      link: termsPath,
+    },
+    privacy: {
+      text: enPrivacyText,
+      link: privacyPath,
+    },
+    useNextLink: true,
+    language: 'en',
+    children: <EnContents />,
+  },
+};

--- a/src/containers/LayoutContainer/LayoutContainer.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { Layout, Props as LayoutProps } from '../../components/Layout';
+
+type Props = LayoutProps;
+
+export const LayoutContainer: React.FC<Props> = ({
+  terms,
+  privacy,
+  useNextLink,
+  language,
+  children,
+}) => (
+  <Layout
+    terms={terms}
+    privacy={privacy}
+    useNextLink={useNextLink}
+    language={language}
+  >
+    {children}
+  </Layout>
+);

--- a/src/containers/LayoutContainer/LayoutContainer.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.tsx
@@ -1,22 +1,90 @@
 import React from 'react';
+import { useSnapshot } from 'valtio';
 
-import { Layout, Props as LayoutProps } from '../../components/Layout';
+import { Layout } from '../../components';
+import {
+  headerStateSelector,
+  updateIsLanguageMenuDisplayed,
+  updateLanguage,
+} from '../../stores/valtio/header';
 
-type Props = LayoutProps;
+type Props = {
+  useNextLink: boolean;
+  children: React.ReactNode;
+};
 
-export const LayoutContainer: React.FC<Props> = ({
-  terms,
-  privacy,
-  useNextLink,
-  language,
-  children,
-}) => (
-  <Layout
-    terms={terms}
-    privacy={privacy}
-    useNextLink={useNextLink}
-    language={language}
-  >
-    {children}
-  </Layout>
-);
+const termsPath = '/terms';
+
+const privacyPath = '/privacy';
+
+const jpTermsText = '利用規約';
+
+const jpPrivacyText = 'プライバシーポリシー';
+
+const enTermsText = 'Terms of Use';
+
+const enPrivacyText = 'Privacy Policy';
+
+const baseUrl = 'https://lgtmeow.com';
+
+const termsUrl = `${baseUrl}${termsPath}` as const;
+
+const privacyUrl = `${baseUrl}${privacyPath}` as const;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const onClickEn = (event: React.MouseEvent<HTMLDivElement>) => {
+  updateLanguage('en');
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const onClickJa = (event: React.MouseEvent<HTMLDivElement>) => {
+  updateLanguage('ja');
+};
+
+export const LayoutContainer: React.FC<Props> = ({ useNextLink, children }) => {
+  const snap = useSnapshot(headerStateSelector());
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const onClickLanguageButton = (event: React.MouseEvent<HTMLDivElement>) => {
+    updateIsLanguageMenuDisplayed(!snap.isLanguageMenuDisplayed);
+  };
+
+  const jaTerms = {
+    text: jpTermsText,
+    link: useNextLink ? termsPath : termsUrl,
+  } as const;
+
+  const jaPrivacy = {
+    text: jpPrivacyText,
+    link: useNextLink ? privacyPath : privacyUrl,
+  } as const;
+
+  const enTerms = {
+    text: enTermsText,
+    link: useNextLink ? termsPath : termsUrl,
+  } as const;
+
+  const enPrivacy = {
+    text: enPrivacyText,
+    link: useNextLink ? privacyPath : privacyUrl,
+  } as const;
+
+  const terms = snap.language === 'ja' ? jaTerms : enTerms;
+
+  const privacy = snap.language === 'ja' ? jaPrivacy : enPrivacy;
+
+  return (
+    <Layout
+      terms={terms}
+      privacy={privacy}
+      useNextLink={useNextLink}
+      isLanguageMenuDisplayed={snap.isLanguageMenuDisplayed}
+      language={snap.language}
+      onClickLanguageButton={onClickLanguageButton}
+      onClickEn={onClickEn}
+      onClickJa={onClickJa}
+    >
+      {children}
+    </Layout>
+  );
+};

--- a/src/containers/LayoutContainer/LayoutContainer.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.tsx
@@ -7,6 +7,8 @@ import {
   updateIsLanguageMenuDisplayed,
   updateLanguage,
 } from '../../stores/valtio/header';
+import { Language } from '../../types/language';
+import assertNever from '../../utils/assertNever';
 
 type Props = {
   useNextLink: boolean;
@@ -41,6 +43,40 @@ const onClickJa = (event: React.MouseEvent<HTMLDivElement>) => {
   updateLanguage('ja');
 };
 
+const createTerms = (language: Language, useNextLink: boolean) => {
+  switch (language) {
+    case 'ja':
+      return {
+        text: jpTermsText,
+        link: useNextLink ? termsPath : termsUrl,
+      } as const;
+    case 'en':
+      return {
+        text: enTermsText,
+        link: useNextLink ? termsPath : termsUrl,
+      } as const;
+    default:
+      return assertNever(language);
+  }
+};
+
+const createPrivacy = (language: Language, useNextLink: boolean) => {
+  switch (language) {
+    case 'ja':
+      return {
+        text: jpPrivacyText,
+        link: useNextLink ? privacyPath : privacyUrl,
+      } as const;
+    case 'en':
+      return {
+        text: enPrivacyText,
+        link: useNextLink ? privacyPath : privacyUrl,
+      } as const;
+    default:
+      return assertNever(language);
+  }
+};
+
 export const LayoutContainer: React.FC<Props> = ({ useNextLink, children }) => {
   const snap = useSnapshot(headerStateSelector());
 
@@ -49,42 +85,32 @@ export const LayoutContainer: React.FC<Props> = ({ useNextLink, children }) => {
     updateIsLanguageMenuDisplayed(!snap.isLanguageMenuDisplayed);
   };
 
-  const jaTerms = {
-    text: jpTermsText,
-    link: useNextLink ? termsPath : termsUrl,
-  } as const;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const onClickOutSideMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    // メニューの外側をクリックしたときだけメニューを閉じる
+    if (snap.isLanguageMenuDisplayed) {
+      updateIsLanguageMenuDisplayed(false);
+    }
+  };
 
-  const jaPrivacy = {
-    text: jpPrivacyText,
-    link: useNextLink ? privacyPath : privacyUrl,
-  } as const;
+  const terms = createTerms(snap.language, useNextLink);
 
-  const enTerms = {
-    text: enTermsText,
-    link: useNextLink ? termsPath : termsUrl,
-  } as const;
-
-  const enPrivacy = {
-    text: enPrivacyText,
-    link: useNextLink ? privacyPath : privacyUrl,
-  } as const;
-
-  const terms = snap.language === 'ja' ? jaTerms : enTerms;
-
-  const privacy = snap.language === 'ja' ? jaPrivacy : enPrivacy;
+  const privacy = createPrivacy(snap.language, useNextLink);
 
   return (
-    <Layout
-      terms={terms}
-      privacy={privacy}
-      useNextLink={useNextLink}
-      isLanguageMenuDisplayed={snap.isLanguageMenuDisplayed}
-      language={snap.language}
-      onClickLanguageButton={onClickLanguageButton}
-      onClickEn={onClickEn}
-      onClickJa={onClickJa}
-    >
-      {children}
-    </Layout>
+    <div onClick={onClickOutSideMenu} aria-hidden="true">
+      <Layout
+        terms={terms}
+        privacy={privacy}
+        useNextLink={useNextLink}
+        isLanguageMenuDisplayed={snap.isLanguageMenuDisplayed}
+        language={snap.language}
+        onClickLanguageButton={onClickLanguageButton}
+        onClickEn={onClickEn}
+        onClickJa={onClickJa}
+      >
+        {children}
+      </Layout>
+    </div>
   );
 };

--- a/src/containers/LayoutContainer/index.ts
+++ b/src/containers/LayoutContainer/index.ts
@@ -1,0 +1,1 @@
+export { LayoutContainer } from './LayoutContainer';

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -1,0 +1,1 @@
+export { LayoutContainer } from './LayoutContainer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './containers';

--- a/src/stores/valtio/header.ts
+++ b/src/stores/valtio/header.ts
@@ -1,0 +1,25 @@
+import { proxy } from 'valtio';
+
+import type { Language } from '../../types/language';
+
+export type HeaderState = {
+  language: Language;
+  isLanguageMenuDisplayed: boolean;
+};
+
+const headerState = proxy<HeaderState>({
+  language: 'ja',
+  isLanguageMenuDisplayed: false,
+});
+
+export const updateLanguage = (language: Language): void => {
+  headerState.language = language;
+};
+
+export const updateIsLanguageMenuDisplayed = (
+  isLanguageMenuDisplayed: boolean,
+): void => {
+  headerState.isLanguageMenuDisplayed = isLanguageMenuDisplayed;
+};
+
+export const headerStateSelector = (): HeaderState => headerState;

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,0 +1,1 @@
+export type Language = 'ja' | 'en';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/42

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/42 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

## Storybook

https://62729802bbcc7d004a663d4c-nsmwkdmyng.chromatic.com/?path=/story/src-containers-layoutcontainer-layoutcontainer-tsx--default

## `storybook-addon-next` を導入して NextRoterをデバッグ出来るようになった

![nextROuter](https://user-images.githubusercontent.com/11032365/172100956-604ce26c-9327-4c2d-925c-a9e73ce16b9b.png)

# 変更点概要

State管理用に `valtio` を導入。

副作用を吸収する為に `LayoutContainer` を実装。

基本的にはアプリケーション側はこの `LayoutContainer` を利用する。

そのほか、NextRoter の動作確認の為`storybook-addon-next` を導入してStorybook上でNextRoterのデバッグが出来るように設定を追加。

# レビュアーに重点的にチェックして欲しい点

インラインコメントに記載。

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
