### PR TITLE
LGTM画像表示用Componentの作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/LgtmImages/LgtmImages.stories.tsx
+++ b/src/components/LgtmImages/LgtmImages.stories.tsx
@@ -9,4 +9,47 @@ export default {
 
 type Story = ComponentStoryObj<typeof LgtmImages>;
 
-export const Default: Story = {};
+const props = [
+  {
+    id: 1,
+    url: 'https://lgtm-images.lgtmeow.com/2021/11/16/22/74046d97-439f-4e11-ad18-a756bcea6131.webp',
+  },
+  {
+    id: 2,
+    url: 'https://lgtm-images.lgtmeow.com/2021/11/16/22/76de320a-b44c-4134-83f1-b874c4ff8663.webp',
+  },
+  {
+    id: 3,
+    url: 'https://lgtm-images.lgtmeow.com/2021/11/16/22/8302f89d-0fda-409d-b0db-0cef2283ed8b.webp',
+  },
+  {
+    id: 4,
+    url: 'https://lgtm-images.lgtmeow.com/2021/11/16/22/a95f34d4-edf9-4dab-b502-2db205375f3c.webp',
+  },
+  {
+    id: 5,
+    url: 'https://lgtm-images.lgtmeow.com/2022/01/21/14/b9ed8f20-16a0-47ef-8e3e-e46e872612fc.webp',
+  },
+  {
+    id: 6,
+    url: 'https://lgtm-images.lgtmeow.com/2022/03/05/00/4057d714-168d-4696-90df-dec57c8957bb.webp',
+  },
+  {
+    id: 7,
+    url: 'https://lgtm-images.lgtmeow.com/2022/04/01/23/a367f362-e26a-43e2-ad61-6c0bd6abdeb2.webp',
+  },
+  {
+    id: 8,
+    url: 'https://lgtm-images.lgtmeow.com/2022/04/16/22/d7d04f68-9c08-4345-ae1e-19db45680588.webp',
+  },
+  {
+    id: 9,
+    url: 'https://lgtm-images.lgtmeow.com/2021/03/16/00/62b7b519-9811-4e05-8c39-3c6dbab0a42d.webp',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    images: props,
+  },
+};

--- a/src/components/LgtmImages/LgtmImages.stories.tsx
+++ b/src/components/LgtmImages/LgtmImages.stories.tsx
@@ -12,7 +12,7 @@ type Story = ComponentStoryObj<typeof LgtmImages>;
 const props = [
   {
     id: 1,
-    url: 'https://lgtm-images.lgtmeow.com/2021/11/16/22/74046d97-439f-4e11-ad18-a756bcea6131.webp',
+    url: 'https://lgtm-images.lgtmeow.com/2022/03/18/23/3086a0f3-52fc-46fa-af82-e9b7d307b155.webp',
   },
   {
     id: 2,

--- a/src/components/LgtmImages/LgtmImages.stories.tsx
+++ b/src/components/LgtmImages/LgtmImages.stories.tsx
@@ -1,0 +1,12 @@
+import { LgtmImages } from './';
+
+import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+export default {
+  title: 'src/components/LgtmImages/LgtmImages.tsx',
+  component: LgtmImages,
+} as Meta<typeof LgtmImages>;
+
+type Story = ComponentStoryObj<typeof LgtmImages>;
+
+export const Default: Story = {};

--- a/src/components/LgtmImages/LgtmImages.tsx
+++ b/src/components/LgtmImages/LgtmImages.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: flex-start;
+  padding: 0;
+`;
+
+const ImageRow = styled.div`
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 20px;
+  align-items: flex-start;
+  order: 0;
+  padding: 0;
+`;
+
+const ImageContents = styled.img`
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+`;
+
+export const LgtmImages = () => (
+  <Wrapper>
+    <ImageRow>
+      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/11/16/22/74046d97-439f-4e11-ad18-a756bcea6131.webp" />
+      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/11/16/22/76de320a-b44c-4134-83f1-b874c4ff8663.webp" />
+      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/11/16/22/8302f89d-0fda-409d-b0db-0cef2283ed8b.webp" />
+    </ImageRow>
+    <ImageRow>
+      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/11/16/22/a95f34d4-edf9-4dab-b502-2db205375f3c.webp" />
+      <ImageContents src="https://lgtm-images.lgtmeow.com/2022/01/21/14/b9ed8f20-16a0-47ef-8e3e-e46e872612fc.webp" />
+      <ImageContents src="https://lgtm-images.lgtmeow.com/2022/03/05/00/4057d714-168d-4696-90df-dec57c8957bb.webp" />
+    </ImageRow>
+    <ImageRow>
+      <ImageContents src="https://lgtm-images.lgtmeow.com/2022/04/01/23/a367f362-e26a-43e2-ad61-6c0bd6abdeb2.webp" />
+      <ImageContents src="https://lgtm-images.lgtmeow.com/2022/04/16/22/d7d04f68-9c08-4345-ae1e-19db45680588.webp" />
+      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/03/16/00/62b7b519-9811-4e05-8c39-3c6dbab0a42d.webp" />
+    </ImageRow>
+  </Wrapper>
+);

--- a/src/components/LgtmImages/LgtmImages.tsx
+++ b/src/components/LgtmImages/LgtmImages.tsx
@@ -2,46 +2,31 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  align-items: flex-start;
-  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(200px, 1fr));
+  gap: 10px;
 `;
 
-const ImageRow = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 20px;
-  align-items: flex-start;
-  order: 0;
-  padding: 0;
+const ImageWrapper = styled.div`
+  align-items: center;
 `;
 
 const ImageContents = styled.img`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
+  object-fit: cover;
 `;
 
-export const LgtmImages = () => (
+type LgtmImage = { id: number; url: string };
+
+type Props = {
+  images: LgtmImage[];
+};
+
+export const LgtmImages: React.FC<Props> = ({ images }) => (
   <Wrapper>
-    <ImageRow>
-      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/11/16/22/74046d97-439f-4e11-ad18-a756bcea6131.webp" />
-      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/11/16/22/76de320a-b44c-4134-83f1-b874c4ff8663.webp" />
-      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/11/16/22/8302f89d-0fda-409d-b0db-0cef2283ed8b.webp" />
-    </ImageRow>
-    <ImageRow>
-      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/11/16/22/a95f34d4-edf9-4dab-b502-2db205375f3c.webp" />
-      <ImageContents src="https://lgtm-images.lgtmeow.com/2022/01/21/14/b9ed8f20-16a0-47ef-8e3e-e46e872612fc.webp" />
-      <ImageContents src="https://lgtm-images.lgtmeow.com/2022/03/05/00/4057d714-168d-4696-90df-dec57c8957bb.webp" />
-    </ImageRow>
-    <ImageRow>
-      <ImageContents src="https://lgtm-images.lgtmeow.com/2022/04/01/23/a367f362-e26a-43e2-ad61-6c0bd6abdeb2.webp" />
-      <ImageContents src="https://lgtm-images.lgtmeow.com/2022/04/16/22/d7d04f68-9c08-4345-ae1e-19db45680588.webp" />
-      <ImageContents src="https://lgtm-images.lgtmeow.com/2021/03/16/00/62b7b519-9811-4e05-8c39-3c6dbab0a42d.webp" />
-    </ImageRow>
+    {images.map((image) => (
+      <ImageWrapper key={image.id}>
+        <ImageContents src={image.url} key={image.id} />
+      </ImageWrapper>
+    ))}
   </Wrapper>
 );

--- a/src/components/LgtmImages/LgtmImages.tsx
+++ b/src/components/LgtmImages/LgtmImages.tsx
@@ -1,18 +1,22 @@
+import Image from 'next/image';
 import React from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
+  @media (max-width: 767px) {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
   display: grid;
-  grid-template-columns: repeat(3, minmax(200px, 1fr));
-  gap: 10px;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 20px;
+  max-width: 900px;
 `;
 
 const ImageWrapper = styled.div`
-  align-items: center;
-`;
-
-const ImageContents = styled.img`
-  object-fit: cover;
+  position: relative;
+  height: 300px;
+  cursor: pointer;
 `;
 
 type LgtmImage = { id: number; url: string };
@@ -25,7 +29,13 @@ export const LgtmImages: React.FC<Props> = ({ images }) => (
   <Wrapper>
     {images.map((image) => (
       <ImageWrapper key={image.id}>
-        <ImageContents src={image.url} key={image.id} />
+        <Image
+          src={image.url}
+          layout="fill"
+          objectFit="contain"
+          alt="lgtm-cat-image"
+          priority={true}
+        />
       </ImageWrapper>
     ))}
   </Wrapper>

--- a/src/components/LgtmImages/index.ts
+++ b/src/components/LgtmImages/index.ts
@@ -1,0 +1,1 @@
+export { LgtmImages } from './LgtmImages';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { Footer } from './Footer';
 export { Header } from './Header';
 export { Layout } from './Layout';
+export { LgtmImages } from './LgtmImages';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/22

# Done の定義

- LGTM画像を表示させるComponentが実装されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-enouumxawr.chromatic.com/?path=/story/src-components-lgtmimages-lgtmimages-tsx--default

# 変更点概要

LGTM画像表示用Componentを実装。

ただし現時点ではFigmaのデザインは再現出来ていない。

`next/image` を利用している点や `LGTMeow` の文字が画像サイズによってバラバラになってしまう問題などがあり、デザインの再現が難しいかもしれない。

https://github.com/keitakn/lgtm-cat-ui-test/pull/3 で動作確認は出来たのでこのPRの範囲はここまでにして、別PRで対応を行う。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
