### PR TITLE
Layoutと一緒にLgtmImagesを表示出来るように調整

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -8,6 +8,12 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
+const ContentsWrapper = styled.div`
+  display: block;
+  margin: 16px auto;
+  text-align: center;
+`;
+
 export type Props = FooterProps & HeaderProps & { children: React.ReactNode };
 
 export const Layout: React.FC<Props> = ({
@@ -29,7 +35,7 @@ export const Layout: React.FC<Props> = ({
       onClickEn={onClickEn}
       onClickJa={onClickJa}
     />
-    {children}
+    <ContentsWrapper>{children}</ContentsWrapper>
     <Footer terms={terms} privacy={privacy} useNextLink={useNextLink} />
   </Wrapper>
 );

--- a/src/components/LgtmImages/LgtmImages.tsx
+++ b/src/components/LgtmImages/LgtmImages.tsx
@@ -14,7 +14,6 @@ const Wrapper = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 20px;
-  max-width: 900px;
 `;
 
 type Props = {

--- a/src/containers/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.stories.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+import { LgtmImages } from '../../components';
+import { CatButtonGroup } from '../../components/Button/CatButtonGroup';
+import { LgtmImage } from '../../types/lgtmImage';
+
 import { LayoutContainer } from './.';
 
 import type { ComponentStoryObj, Meta } from '@storybook/react';
@@ -19,6 +23,54 @@ const JpContents: React.FC = () => (
   </>
 );
 
+const images: LgtmImage[] = [
+  {
+    id: 1,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2022/03/18/23/3086a0f3-52fc-46fa-af82-e9b7d307b155.webp',
+  } as const,
+  {
+    id: 2,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2021/11/16/22/76de320a-b44c-4134-83f1-b874c4ff8663.webp',
+  } as const,
+  {
+    id: 3,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2021/11/16/22/8302f89d-0fda-409d-b0db-0cef2283ed8b.webp',
+  } as const,
+  {
+    id: 4,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2021/11/16/22/a95f34d4-edf9-4dab-b502-2db205375f3c.webp',
+  } as const,
+  {
+    id: 5,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2022/01/21/14/b9ed8f20-16a0-47ef-8e3e-e46e872612fc.webp',
+  } as const,
+  {
+    id: 6,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2022/03/05/00/4057d714-168d-4696-90df-dec57c8957bb.webp',
+  } as const,
+  {
+    id: 7,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2022/04/01/23/a367f362-e26a-43e2-ad61-6c0bd6abdeb2.webp',
+  } as const,
+  {
+    id: 8,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2022/04/16/22/d7d04f68-9c08-4345-ae1e-19db45680588.webp',
+  } as const,
+  {
+    id: 9,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2021/03/16/00/62b7b519-9811-4e05-8c39-3c6dbab0a42d.webp',
+  } as const,
+];
+
 export const Default: Story = {
   args: {
     useNextLink: false,
@@ -30,5 +82,22 @@ export const WithNextLink: Story = {
   args: {
     useNextLink: true,
     children: <JpContents />,
+  },
+};
+
+const LgtmImagesWithText = () => (
+  <>
+    <h1>タイトル</h1>
+    <h2>サブタイトル</h2>
+    <p>コンテンツ</p>
+    <CatButtonGroup />
+    <LgtmImages images={images} />
+  </>
+);
+
+export const WithLgtmImages: Story = {
+  args: {
+    useNextLink: true,
+    children: <LgtmImagesWithText />,
   },
 };


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/22

# Done の定義

- Layoutと一緒にLgtmImagesを表示出来るようにCSSの調整が行われている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-riusbbzinc.chromatic.com/?path=/story/src-containers-layoutcontainer-layoutcontainer-tsx--with-lgtm-images

# 変更点概要

`LayoutContainer` のStorybookに `LgtmImages` と `ButtonGroup` を表示させるパターンを追加。

これによって中央揃いでContentsが表示出来ている事を確認出来た。

しかし `LayoutContainer` のStorybookにあるのが微妙なのでトップページ用のpagesComponentを作成して、そこの部分のStorybookで表現するように別issueを作成して対応する。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
