### PR TITLE
LgtmImageContent にコールバック関数を受け取れるように改修

### DIFF
--- a/src/components/LgtmImages/LgtmImageContent.tsx
+++ b/src/components/LgtmImages/LgtmImageContent.tsx
@@ -19,19 +19,29 @@ const ImageWrapper = styled.div`
 
 type Props = LgtmImage & {
   appUrl?: AppUrl;
+  callback?: () => void;
 };
 
-export const LgtmImageContent: React.FC<Props> = ({ id, imageUrl, appUrl }) => {
+export const LgtmImageContent: React.FC<Props> = ({
+  id,
+  imageUrl,
+  appUrl,
+  callback,
+}) => {
   const [copied, setCopied] = React.useState(false);
 
   const onCopySuccess = React.useCallback(() => {
+    if (callback) {
+      callback();
+    }
+
     const messageDisplayTime = 1000;
 
     setCopied(true);
     setTimeout(() => {
       setCopied(false);
     }, messageDisplayTime);
-  }, []);
+  }, [callback]);
 
   const { imageContextRef } = useClipboardMarkdown({
     onCopySuccess,

--- a/src/components/LgtmImages/LgtmImages.stories.tsx
+++ b/src/components/LgtmImages/LgtmImages.stories.tsx
@@ -71,3 +71,11 @@ export const WithAppUrl: Story = {
     appUrl: 'http://localhost:2222',
   },
 };
+
+export const WithCallbackFunc: Story = {
+  args: {
+    images,
+    // eslint-disable-next-line no-alert
+    callback: () => alert('run callback func!'),
+  },
+};

--- a/src/components/LgtmImages/LgtmImages.tsx
+++ b/src/components/LgtmImages/LgtmImages.tsx
@@ -19,9 +19,10 @@ const Wrapper = styled.div`
 type Props = {
   images: LgtmImage[];
   appUrl?: AppUrl;
+  callback?: () => void;
 };
 
-export const LgtmImages: React.FC<Props> = ({ images, appUrl }) => (
+export const LgtmImages: React.FC<Props> = ({ images, appUrl, callback }) => (
   <Wrapper>
     {images.map((image) => (
       <LgtmImageContent
@@ -29,6 +30,7 @@ export const LgtmImages: React.FC<Props> = ({ images, appUrl }) => (
         imageUrl={image.imageUrl}
         key={image.id}
         appUrl={appUrl}
+        callback={callback}
       />
     ))}
   </Wrapper>


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/22

# Done の定義

- LgtmImageContentにコールバック関数を渡せるように改修されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-jnjaapxxlm.chromatic.com/?path=/story/src-components-lgtmimages-lgtmimages-tsx--with-callback-func

# 変更点概要

表題の通りの改修を実施。

コールバック関数はGAにイベントを送信する時などに利用する想定。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
