### PR TITLE
Footerは next/link を決め打ちで利用する形に変更

### DIFF
--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -21,21 +21,15 @@ const enTermsText = 'Terms of Use';
 
 const enPrivacyText = 'Privacy Policy';
 
-const baseUrl = 'https://lgtmeow.com';
-
-const termsUrl = `${baseUrl}${termsPath}` as const;
-
-const privacyUrl = `${baseUrl}${privacyPath}` as const;
-
 export const ViewInJapanese: Story = {
   args: {
     terms: {
       text: jpTermsText,
-      link: termsUrl,
+      link: termsPath,
     },
     privacy: {
       text: jpPrivacyText,
-      link: privacyUrl,
+      link: privacyPath,
     },
   },
 };
@@ -44,39 +38,11 @@ export const ViewInEnglish: Story = {
   args: {
     terms: {
       text: enTermsText,
-      link: termsUrl,
-    },
-    privacy: {
-      text: enPrivacyText,
-      link: privacyUrl,
-    },
-  },
-};
-
-export const ViewInJapaneseWithNextLink: Story = {
-  args: {
-    terms: {
-      text: jpTermsText,
-      link: termsPath,
-    },
-    privacy: {
-      text: jpPrivacyText,
-      link: privacyPath,
-    },
-    useNextLink: true,
-  },
-};
-
-export const ViewInEnglishWithNextLink: Story = {
-  args: {
-    terms: {
-      text: enTermsText,
       link: termsPath,
     },
     privacy: {
       text: enPrivacyText,
       link: privacyPath,
     },
-    useNextLink: true,
   },
 };

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -104,48 +104,19 @@ type LinkAttribute = {
 export type Props = {
   terms: LinkAttribute;
   privacy: LinkAttribute;
-  useNextLink: true | false;
 };
 
-type TermsLinkTextWithNextLinkProps = {
-  terms: LinkAttribute;
-};
-
-const TermsLinkTextWithNextLink: React.FC<TermsLinkTextWithNextLinkProps> = ({
-  terms,
-}) => (
-  <Link href={terms.link} prefetch={false}>
-    <TermsLinkText>{terms.text}</TermsLinkText>
-  </Link>
-);
-
-type PrivacyLinkTextWithNextLinkProps = {
-  privacy: LinkAttribute;
-};
-
-const PrivacyLinkTextWithNextLink: React.FC<
-  PrivacyLinkTextWithNextLinkProps
-> = ({ privacy }) => (
-  <Link href={privacy.link} prefetch={false}>
-    <PrivacyLinkText>{privacy.text}</PrivacyLinkText>
-  </Link>
-);
-
-export const Footer: React.FC<Props> = ({ terms, privacy, useNextLink }) => (
+export const Footer: React.FC<Props> = ({ terms, privacy }) => (
   <StyledFooter>
     <UpperSection>
-      {useNextLink ? (
-        <TermsLinkTextWithNextLink terms={terms} />
-      ) : (
-        <TermsLinkText href={terms.link}>{terms.text}</TermsLinkText>
-      )}
+      <Link href={terms.link} prefetch={false}>
+        <TermsLinkText>{terms.text}</TermsLinkText>
+      </Link>
       {/* eslint-disable no-irregular-whitespace */}
       <SeparatorText> / </SeparatorText>
-      {useNextLink ? (
-        <PrivacyLinkTextWithNextLink privacy={privacy} />
-      ) : (
-        <PrivacyLinkText href={privacy.link}>{privacy.text}</PrivacyLinkText>
-      )}
+      <Link href={privacy.link} prefetch={false}>
+        <PrivacyLinkText>{privacy.text}</PrivacyLinkText>
+      </Link>
     </UpperSection>
     <LowerSection>
       <LowerSectionText>Copyright (c) nekochans</LowerSectionText>

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -23,12 +23,6 @@ const enTermsText = 'Terms of Use';
 
 const enPrivacyText = 'Privacy Policy';
 
-const baseUrl = 'https://lgtmeow.com';
-
-const termsUrl = `${baseUrl}${termsPath}` as const;
-
-const privacyUrl = `${baseUrl}${privacyPath}` as const;
-
 const JpContents: React.FC = () => (
   <>
     <h1>タイトル</h1>
@@ -49,11 +43,11 @@ export const ViewInJapanese: Story = {
   args: {
     terms: {
       text: jpTermsText,
-      link: termsUrl,
+      link: termsPath,
     },
     privacy: {
       text: jpPrivacyText,
-      link: privacyUrl,
+      link: privacyPath,
     },
     language: 'ja',
     children: <JpContents />,
@@ -64,44 +58,12 @@ export const ViewInEnglish: Story = {
   args: {
     terms: {
       text: enTermsText,
-      link: termsUrl,
-    },
-    privacy: {
-      text: enPrivacyText,
-      link: privacyUrl,
-    },
-    language: 'en',
-    children: <EnContents />,
-  },
-};
-
-export const ViewInJapaneseWithNextLink: Story = {
-  args: {
-    terms: {
-      text: jpTermsText,
-      link: termsPath,
-    },
-    privacy: {
-      text: jpPrivacyText,
-      link: privacyPath,
-    },
-    useNextLink: true,
-    language: 'ja',
-    children: <JpContents />,
-  },
-};
-
-export const ViewInEnglishWithNextLink: Story = {
-  args: {
-    terms: {
-      text: enTermsText,
       link: termsPath,
     },
     privacy: {
       text: enPrivacyText,
       link: privacyPath,
     },
-    useNextLink: true,
     language: 'en',
     children: <EnContents />,
   },

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -19,7 +19,6 @@ export type Props = FooterProps & HeaderProps & { children: React.ReactNode };
 export const Layout: React.FC<Props> = ({
   terms,
   privacy,
-  useNextLink,
   language,
   isLanguageMenuDisplayed,
   onClickLanguageButton,
@@ -36,6 +35,6 @@ export const Layout: React.FC<Props> = ({
       onClickJa={onClickJa}
     />
     <ContentsWrapper>{children}</ContentsWrapper>
-    <Footer terms={terms} privacy={privacy} useNextLink={useNextLink} />
+    <Footer terms={terms} privacy={privacy} />
   </Wrapper>
 );

--- a/src/containers/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.stories.tsx
@@ -73,14 +73,6 @@ const images: LgtmImage[] = [
 
 export const Default: Story = {
   args: {
-    useNextLink: false,
-    children: <JpContents />,
-  },
-};
-
-export const WithNextLink: Story = {
-  args: {
-    useNextLink: true,
     children: <JpContents />,
   },
 };
@@ -97,7 +89,6 @@ const LgtmImagesWithText = () => (
 
 export const WithLgtmImages: Story = {
   args: {
-    useNextLink: true,
     children: <LgtmImagesWithText />,
   },
 };

--- a/src/containers/LayoutContainer/LayoutContainer.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.tsx
@@ -11,7 +11,6 @@ import { Language } from '../../types/language';
 import assertNever from '../../utils/assertNever';
 
 type Props = {
-  useNextLink: boolean;
   children: React.ReactNode;
 };
 
@@ -27,12 +26,6 @@ const enTermsText = 'Terms of Use';
 
 const enPrivacyText = 'Privacy Policy';
 
-const baseUrl = 'https://lgtmeow.com';
-
-const termsUrl = `${baseUrl}${termsPath}` as const;
-
-const privacyUrl = `${baseUrl}${privacyPath}` as const;
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const onClickEn = (event: React.MouseEvent<HTMLDivElement>) => {
   updateLanguage('en');
@@ -43,41 +36,41 @@ const onClickJa = (event: React.MouseEvent<HTMLDivElement>) => {
   updateLanguage('ja');
 };
 
-const createTerms = (language: Language, useNextLink: boolean) => {
+const createTerms = (language: Language) => {
   switch (language) {
     case 'ja':
       return {
         text: jpTermsText,
-        link: useNextLink ? termsPath : termsUrl,
+        link: termsPath,
       } as const;
     case 'en':
       return {
         text: enTermsText,
-        link: useNextLink ? termsPath : termsUrl,
+        link: termsPath,
       } as const;
     default:
       return assertNever(language);
   }
 };
 
-const createPrivacy = (language: Language, useNextLink: boolean) => {
+const createPrivacy = (language: Language) => {
   switch (language) {
     case 'ja':
       return {
         text: jpPrivacyText,
-        link: useNextLink ? privacyPath : privacyUrl,
+        link: privacyPath,
       } as const;
     case 'en':
       return {
         text: enPrivacyText,
-        link: useNextLink ? privacyPath : privacyUrl,
+        link: privacyPath,
       } as const;
     default:
       return assertNever(language);
   }
 };
 
-export const LayoutContainer: React.FC<Props> = ({ useNextLink, children }) => {
+export const LayoutContainer: React.FC<Props> = ({ children }) => {
   const snap = useSnapshot(headerStateSelector());
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -93,16 +86,15 @@ export const LayoutContainer: React.FC<Props> = ({ useNextLink, children }) => {
     }
   };
 
-  const terms = createTerms(snap.language, useNextLink);
+  const terms = createTerms(snap.language);
 
-  const privacy = createPrivacy(snap.language, useNextLink);
+  const privacy = createPrivacy(snap.language);
 
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">
       <Layout
         terms={terms}
         privacy={privacy}
-        useNextLink={useNextLink}
         isLanguageMenuDisplayed={snap.isLanguageMenuDisplayed}
         language={snap.language}
         onClickLanguageButton={onClickLanguageButton}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/55

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/55 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

[optional] ただし UI 変更の時は [required]

# 変更点概要

当初はNext.jsに依存した形を避ける為に通常の `<a>` タグも利用出来るようにしていたが、本packageはあくまでもデザイナーさんとのコミュニケーションの為に作られた側面が強く、LGTMeow以外で汎用的に利用出来るようなデザインシステムは目指していない。

よって `next/link` に依存する実装であっても問題ないと判断した。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。