### PR TITLE
言語メニューのButton横のFaCaretDownアイコンの位置がズレていたので修正

### DIFF
--- a/src/components/Header/LanguageButton.tsx
+++ b/src/components/Header/LanguageButton.tsx
@@ -31,14 +31,17 @@ const Text = styled.p`
   color: #eb7c06;
 `;
 
+const faCaretDownStyle = {
+  color: '#eb7c06',
+};
+
 type Props = {
   onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
 };
 
 export const LanguageButton: React.FC<Props> = ({ onClick }) => (
   <Wrapper onClick={onClick}>
-    <Text>
-      Language <FaCaretDown />
-    </Text>
+    <Text>Language</Text>
+    <FaCaretDown style={faCaretDownStyle} />
   </Wrapper>
 );


### PR DESCRIPTION
# issueURL

なし

# Done の定義

- 言語メニューのButton横のFaCaretDownアイコンの位置がテキストと平行して表示されるようになっている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-bsrwtgpstn.chromatic.com/?path=/story/src-components-header-header-tsx--language-ja

# 変更点概要

言語メニューのButtonの隣にあるアイコンの位置がおかしかったので調整。

# レビュアーに重点的にチェックして欲しい点

特になし。

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。

