### PR TITLE
トップページに配置するサービス説明用のComponentを追加

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,6 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Roboto&family=Zen+Kaku+Gothic+New&display=swap"
   rel="stylesheet"
 />

--- a/src/components/AppDescriptionArea/AppDescriptionArea.stories.tsx
+++ b/src/components/AppDescriptionArea/AppDescriptionArea.stories.tsx
@@ -1,0 +1,12 @@
+import { AppDescriptionArea } from './';
+
+import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+export default {
+  title: 'src/components/AppDescriptionArea/AppDescriptionArea.tsx',
+  component: AppDescriptionArea,
+} as Meta<typeof AppDescriptionArea>;
+
+type Story = ComponentStoryObj<typeof AppDescriptionArea>;
+
+export const Default: Story = {};

--- a/src/components/AppDescriptionArea/AppDescriptionArea.stories.tsx
+++ b/src/components/AppDescriptionArea/AppDescriptionArea.stories.tsx
@@ -9,4 +9,10 @@ export default {
 
 type Story = ComponentStoryObj<typeof AppDescriptionArea>;
 
-export const Default: Story = {};
+export const ViewInJapanese: Story = {
+  args: { language: 'ja' },
+};
+
+export const ViewInEnglish: Story = {
+  args: { language: 'en' },
+};

--- a/src/components/AppDescriptionArea/AppDescriptionArea.tsx
+++ b/src/components/AppDescriptionArea/AppDescriptionArea.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div``;
+
+const JaText = styled.div`
+  font-family: Zen Kaku Gothic New, sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 28px;
+  color: #43281e;
+  text-align: center;
+`;
+
+export const AppDescriptionArea: React.FC = () => (
+  <Wrapper>
+    <JaText>猫のLGTM画像を共有出来るサービスです。</JaText>
+    <JaText>画像をクリックするとGitHub Markdownがコピーされます。</JaText>
+  </Wrapper>
+);

--- a/src/components/AppDescriptionArea/AppDescriptionArea.tsx
+++ b/src/components/AppDescriptionArea/AppDescriptionArea.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { Language } from '../../types/language';
+import assertNever from '../../utils/assertNever';
+
 const Wrapper = styled.div``;
 
 const JaText = styled.div`
@@ -13,9 +16,50 @@ const JaText = styled.div`
   text-align: center;
 `;
 
-export const AppDescriptionArea: React.FC = () => (
+const EnText = styled.div`
+  font-family: Roboto, sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 28px;
+  color: #43281e;
+  text-align: center;
+`;
+
+const jaUpperSectionText = '猫のLGTM画像を共有出来るサービスです。';
+
+const jaLowerSectionText =
+  '画像をクリックするとGitHub Markdownがコピーされます。';
+
+const enUpperSectionText = 'Cat LGTM Image Service.';
+
+const enLowerSectionText = 'Click on the image to copy the GitHub Markdown.';
+
+export type Props = {
+  language: Language;
+};
+
+const JaAppDescriptionArea: React.FC = () => (
   <Wrapper>
-    <JaText>猫のLGTM画像を共有出来るサービスです。</JaText>
-    <JaText>画像をクリックするとGitHub Markdownがコピーされます。</JaText>
+    <JaText>{jaUpperSectionText}</JaText>
+    <JaText>{jaLowerSectionText}</JaText>
   </Wrapper>
 );
+
+const EnAppDescriptionArea: React.FC = () => (
+  <Wrapper>
+    <EnText>{enUpperSectionText}</EnText>
+    <EnText>{enLowerSectionText}</EnText>
+  </Wrapper>
+);
+
+export const AppDescriptionArea: React.FC<Props> = ({ language }) => {
+  switch (language) {
+    case 'ja':
+      return <JaAppDescriptionArea />;
+    case 'en':
+      return <EnAppDescriptionArea />;
+    default:
+      return assertNever(language);
+  }
+};

--- a/src/components/AppDescriptionArea/AppDescriptionArea.tsx
+++ b/src/components/AppDescriptionArea/AppDescriptionArea.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Language } from '../../types/language';
 import assertNever from '../../utils/assertNever';
 
 const Wrapper = styled.div``;
 
-const JaText = styled.div`
-  font-family: Zen Kaku Gothic New, sans-serif;
+const textStyle = css`
   font-size: 14px;
   font-style: normal;
   font-weight: 400;
@@ -16,14 +15,14 @@ const JaText = styled.div`
   text-align: center;
 `;
 
+const JaText = styled.div`
+  font-family: Zen Kaku Gothic New, sans-serif;
+  ${textStyle};
+`;
+
 const EnText = styled.div`
   font-family: Roboto, sans-serif;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 28px;
-  color: #43281e;
-  text-align: center;
+  ${textStyle};
 `;
 
 const jaUpperSectionText = '猫のLGTM画像を共有出来るサービスです。';

--- a/src/components/AppDescriptionArea/index.ts
+++ b/src/components/AppDescriptionArea/index.ts
@@ -1,0 +1,1 @@
+export { AppDescriptionArea } from './AppDescriptionArea';

--- a/src/containers/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { LgtmImages } from '../../components';
+import { AppDescriptionArea } from '../../components/AppDescriptionArea';
 import { CatButtonGroup } from '../../components/Button/CatButtonGroup';
 import { LgtmImage } from '../../types/lgtmImage';
 
@@ -79,9 +80,7 @@ export const Default: Story = {
 
 const LgtmImagesWithText = () => (
   <>
-    <h1>タイトル</h1>
-    <h2>サブタイトル</h2>
-    <p>コンテンツ</p>
+    <AppDescriptionArea />
     <CatButtonGroup />
     <LgtmImages images={images} />
   </>

--- a/src/containers/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/containers/LayoutContainer/LayoutContainer.stories.tsx
@@ -80,7 +80,7 @@ export const Default: Story = {
 
 const LgtmImagesWithText = () => (
   <>
-    <AppDescriptionArea />
+    <AppDescriptionArea language="ja" />
     <CatButtonGroup />
     <LgtmImages images={images} />
   </>


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/49

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/49 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-ycomqdkxrt.chromatic.com/?path=/story/src-components-appdescriptionarea-appdescriptionarea-tsx--view-in-japanese

https://62729802bbcc7d004a663d4c-ycomqdkxrt.chromatic.com/?path=/story/src-containers-layoutcontainer-layoutcontainer-tsx--with-lgtm-images

# 変更点概要

トップページに配置する、サービス説明用のComponentが追加。

日本語と英語での文言を用意してある。

# レビュアーに重点的にチェックして欲しい点

文言に問題がないか確認してもらえると:pray:

# 補足情報

特になし
