### PR TITLE
フォーカスを当てた時のマウスカーソルの種類を調整

### DIFF
--- a/src/components/Button/BackToTopButton/BackToTopButton.tsx
+++ b/src/components/Button/BackToTopButton/BackToTopButton.tsx
@@ -9,6 +9,7 @@ const StyledSpan = styled.span`
   align-items: center;
   justify-content: center;
   padding: 8px 20px;
+  cursor: pointer;
   background: #eb7c06;
   border-radius: 4px;
   &:hover {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -36,6 +36,7 @@ const TermsLinkText = styled.a`
   color: #43281e;
   text-align: center;
   text-decoration-line: underline;
+  cursor: pointer;
 `;
 
 const PrivacyLinkText = styled.a`
@@ -51,6 +52,7 @@ const PrivacyLinkText = styled.a`
   color: #43281e;
   text-align: center;
   text-decoration-line: underline;
+  cursor: pointer;
 `;
 
 const SeparatorText = styled.div`

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -46,6 +46,7 @@ const faBarsStyle = {
   flex: 'none',
   order: 0,
   flexGrow: 0,
+  cursor: 'pointer',
 };
 
 export type Props = LanguageMenuProps & {

--- a/src/components/Header/LanguageButton.tsx
+++ b/src/components/Header/LanguageButton.tsx
@@ -29,10 +29,12 @@ const Text = styled.p`
   font-weight: 700;
   line-height: 19px;
   color: #eb7c06;
+  cursor: pointer;
 `;
 
 const faCaretDownStyle = {
   color: '#eb7c06',
+  cursor: 'pointer',
 };
 
 type Props = {

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -43,6 +43,7 @@ const EnText = styled.div`
   font-weight: 400;
   line-height: 19px;
   color: #faf9f7;
+  cursor: pointer;
 `;
 
 const Separator = styled.div`
@@ -65,6 +66,7 @@ const JaText = styled.div`
   font-weight: 900;
   line-height: 19px;
   color: #faf9f7;
+  cursor: pointer;
 `;
 
 export type Props = {

--- a/src/styles/mixins.ts
+++ b/src/styles/mixins.ts
@@ -10,6 +10,7 @@ const buttonBase = css`
   order: 1;
   width: fit-content;
   padding: 7px 20px;
+  cursor: pointer;
   border-radius: 4px;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
   &:hover {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/62

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/62 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-hboljyojpi.chromatic.com/?path=/story/src-containers-responsivelayoutcontainer-responsivelayoutcontainer-tsx--default

# 変更点概要

https://developer.mozilla.org/ja/docs/Web/CSS/cursor を参考にクリック可能な要素は基本的に `cursor: pointer;` を指定するように変更。

これで少しは自然になったと思う。

# レビュアーに重点的にチェックして欲しい点

LGTM画像は `cursor: copy;` とかのほうが良いかな？意見を聞かせてもらえると:pray:

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。