### PR TITLE
言語メニュー部分のクリック範囲を拡大する

### DIFF
--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -57,7 +57,7 @@ const Separator = styled.div`
   order: 1;
   width: 125px;
   height: 0;
-  border: 1px solid rgba(54, 46, 43, 0.4);
+  border: 1px solid rgba(54, 46, 43, 0.5);
 `;
 
 const JaTextWrapper = styled.button`

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -13,29 +13,29 @@ const StyledLanguageMenu = styled.div`
   bottom: -70px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
   align-items: center;
-  padding: 10px 0;
-  background: rgba(54, 46, 43, 0.4);
+  padding: 0;
 `;
 
 const Wrapper = styled.div`
   display: flex;
   flex: none;
-  flex-direction: column;
+  flex-direction: row;
   flex-grow: 0;
   gap: 10px;
-  align-items: center;
+  align-items: flex-start;
   order: 0;
   width: 125px;
-  height: 58px;
-  padding: 0;
+  height: 39px;
+  padding: 10px 0;
+  background: rgba(54, 46, 43, 0.4);
 `;
 
 const EnText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
+  width: 125px;
   height: 19px;
   font-family: Roboto, sans-serif;
   font-size: 16px;
@@ -43,6 +43,7 @@ const EnText = styled.div`
   font-weight: 400;
   line-height: 19px;
   color: #faf9f7;
+  text-align: center;
   cursor: pointer;
 `;
 
@@ -52,20 +53,22 @@ const Separator = styled.div`
   order: 1;
   width: 125px;
   height: 0;
-  border: 1px solid rgba(54, 46, 43, 0.5);
+  border: 1px solid rgba(54, 46, 43, 0.4);
 `;
 
 const JaText = styled.div`
   flex: none;
   flex-grow: 0;
-  order: 2;
+  order: 0;
+  width: 125px;
   height: 19px;
   font-family: Roboto, sans-serif;
   font-size: 16px;
   font-style: normal;
-  font-weight: 900;
+  font-weight: 400;
   line-height: 19px;
   color: #faf9f7;
+  text-align: center;
   cursor: pointer;
 `;
 
@@ -86,7 +89,9 @@ export const LanguageMenu: React.FC<Props> = ({
         {language === 'en' ? <FaAngleRight /> : ''}
         English
       </EnText>
-      <Separator />
+    </Wrapper>
+    <Separator />
+    <Wrapper>
       <JaText onClick={onClickJa}>
         {language === 'ja' ? <FaAngleRight /> : ''}
         日本語

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -17,7 +17,7 @@ const StyledLanguageMenu = styled.div`
   padding: 0;
 `;
 
-const Wrapper = styled.div`
+const EnTextWrapper = styled.div`
   display: flex;
   flex: none;
   flex-direction: row;
@@ -56,6 +56,20 @@ const Separator = styled.div`
   border: 1px solid rgba(54, 46, 43, 0.4);
 `;
 
+const JaTextWrapper = styled.div`
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: flex-start;
+  order: 2;
+  width: 125px;
+  height: 39px;
+  padding: 10px 0;
+  background: rgba(54, 46, 43, 0.4);
+`;
+
 const JaText = styled.div`
   flex: none;
   flex-grow: 0;
@@ -84,18 +98,18 @@ export const LanguageMenu: React.FC<Props> = ({
   onClickJa,
 }) => (
   <StyledLanguageMenu>
-    <Wrapper>
+    <EnTextWrapper>
       <EnText onClick={onClickEn}>
         {language === 'en' ? <FaAngleRight /> : ''}
         English
       </EnText>
-    </Wrapper>
+    </EnTextWrapper>
     <Separator />
-    <Wrapper>
+    <JaTextWrapper>
       <JaText onClick={onClickJa}>
         {language === 'ja' ? <FaAngleRight /> : ''}
         日本語
       </JaText>
-    </Wrapper>
+    </JaTextWrapper>
   </StyledLanguageMenu>
 );

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -1,8 +1,21 @@
 import React from 'react';
 import { FaAngleRight } from 'react-icons/fa';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Language } from '../../types/language';
+
+const textWrapperStyle = css`
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: flex-start;
+  width: 125px;
+  height: 39px;
+  padding: 10px 0;
+  background: rgba(54, 46, 43, 0.4);
+`;
 
 const StyledLanguageMenu = styled.div`
   @media (max-width: 767px) {
@@ -18,17 +31,8 @@ const StyledLanguageMenu = styled.div`
 `;
 
 const EnTextWrapper = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: flex-start;
+  ${textWrapperStyle};
   order: 0;
-  width: 125px;
-  height: 39px;
-  padding: 10px 0;
-  background: rgba(54, 46, 43, 0.4);
 `;
 
 const EnText = styled.div`
@@ -57,17 +61,8 @@ const Separator = styled.div`
 `;
 
 const JaTextWrapper = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: flex-start;
+  ${textWrapperStyle};
   order: 2;
-  width: 125px;
-  height: 39px;
-  padding: 10px 0;
-  background: rgba(54, 46, 43, 0.4);
 `;
 
 const JaText = styled.div`

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -30,7 +30,7 @@ const StyledLanguageMenu = styled.div`
   padding: 0;
 `;
 
-const EnTextWrapper = styled.div`
+const EnTextWrapper = styled.button`
   ${textWrapperStyle};
   order: 0;
 `;
@@ -60,7 +60,7 @@ const Separator = styled.div`
   border: 1px solid rgba(54, 46, 43, 0.4);
 `;
 
-const JaTextWrapper = styled.div`
+const JaTextWrapper = styled.button`
   ${textWrapperStyle};
   order: 2;
 `;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/74

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/74 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-xwmecjquoo.chromatic.com/?path=/story/src-containers-responsivelayoutcontainer-responsivelayoutcontainer-tsx--default

# 変更点概要

言語切り替えボタンのクリック範囲が「日本語」「English」のテキストの上限定になっていたのでデザインを変更してクリック範囲を拡大した。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
