### PR TITLE
テキストは言語情報に応じてComponent内部で切り替えるように変更

### DIFF
--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -9,40 +9,10 @@ export default {
 
 type Story = ComponentStoryObj<typeof Footer>;
 
-const termsPath = '/terms';
-
-const privacyPath = '/privacy';
-
-const jpTermsText = '利用規約';
-
-const jpPrivacyText = 'プライバシーポリシー';
-
-const enTermsText = 'Terms of Use';
-
-const enPrivacyText = 'Privacy Policy';
-
 export const ViewInJapanese: Story = {
-  args: {
-    terms: {
-      text: jpTermsText,
-      link: termsPath,
-    },
-    privacy: {
-      text: jpPrivacyText,
-      link: privacyPath,
-    },
-  },
+  args: { language: 'ja' },
 };
 
 export const ViewInEnglish: Story = {
-  args: {
-    terms: {
-      text: enTermsText,
-      link: termsPath,
-    },
-    privacy: {
-      text: enPrivacyText,
-      link: privacyPath,
-    },
-  },
+  args: { language: 'en' },
 };

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -2,6 +2,10 @@ import Link from 'next/link';
 import React from 'react';
 import styled from 'styled-components';
 
+import { createLinksFromLanguages as createPrivacyLinksFromLanguages } from '../../features/privacyPolicy';
+import { createLinksFromLanguages as createTermsLinksFromLanguages } from '../../features/termsOfUse';
+import { Language } from '../../types/language';
+
 const StyledFooter = styled.div`
   position: relative;
   display: flex;
@@ -98,30 +102,30 @@ const LowerSectionText = styled.div`
   color: #43281e;
 `;
 
-type LinkAttribute = {
-  text: string;
-  link: `https://${string}` | `/${string}`;
-};
-
 export type Props = {
-  terms: LinkAttribute;
-  privacy: LinkAttribute;
+  language: Language;
 };
 
-export const Footer: React.FC<Props> = ({ terms, privacy }) => (
-  <StyledFooter>
-    <UpperSection>
-      <Link href={terms.link} prefetch={false}>
-        <TermsLinkText>{terms.text}</TermsLinkText>
-      </Link>
-      {/* eslint-disable no-irregular-whitespace */}
-      <SeparatorText> / </SeparatorText>
-      <Link href={privacy.link} prefetch={false}>
-        <PrivacyLinkText>{privacy.text}</PrivacyLinkText>
-      </Link>
-    </UpperSection>
-    <LowerSection>
-      <LowerSectionText>Copyright (c) nekochans</LowerSectionText>
-    </LowerSection>
-  </StyledFooter>
-);
+export const Footer: React.FC<Props> = ({ language }) => {
+  const terms = createTermsLinksFromLanguages(language);
+
+  const privacy = createPrivacyLinksFromLanguages(language);
+
+  return (
+    <StyledFooter>
+      <UpperSection>
+        <Link href={terms.link} prefetch={false}>
+          <TermsLinkText>{terms.text}</TermsLinkText>
+        </Link>
+        {/* eslint-disable no-irregular-whitespace */}
+        <SeparatorText> / </SeparatorText>
+        <Link href={privacy.link} prefetch={false}>
+          <PrivacyLinkText>{privacy.text}</PrivacyLinkText>
+        </Link>
+      </UpperSection>
+      <LowerSection>
+        <LowerSectionText>Copyright (c) nekochans</LowerSectionText>
+      </LowerSection>
+    </StyledFooter>
+  );
+};

--- a/src/containers/ResponsiveLayoutContainer/ResponsiveLayoutContainer.tsx
+++ b/src/containers/ResponsiveLayoutContainer/ResponsiveLayoutContainer.tsx
@@ -7,24 +7,10 @@ import {
   updateIsLanguageMenuDisplayed,
   updateLanguage,
 } from '../../stores/valtio/header';
-import { Language } from '../../types/language';
-import assertNever from '../../utils/assertNever';
 
 type Props = {
   children: React.ReactNode;
 };
-
-const termsPath = '/terms';
-
-const privacyPath = '/privacy';
-
-const jpTermsText = '利用規約';
-
-const jpPrivacyText = 'プライバシーポリシー';
-
-const enTermsText = 'Terms of Use';
-
-const enPrivacyText = 'Privacy Policy';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const onClickEn = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -34,40 +20,6 @@ const onClickEn = (event: React.MouseEvent<HTMLDivElement>) => {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const onClickJa = (event: React.MouseEvent<HTMLDivElement>) => {
   updateLanguage('ja');
-};
-
-const createTerms = (language: Language) => {
-  switch (language) {
-    case 'ja':
-      return {
-        text: jpTermsText,
-        link: termsPath,
-      } as const;
-    case 'en':
-      return {
-        text: enTermsText,
-        link: termsPath,
-      } as const;
-    default:
-      return assertNever(language);
-  }
-};
-
-const createPrivacy = (language: Language) => {
-  switch (language) {
-    case 'ja':
-      return {
-        text: jpPrivacyText,
-        link: privacyPath,
-      } as const;
-    case 'en':
-      return {
-        text: enPrivacyText,
-        link: privacyPath,
-      } as const;
-    default:
-      return assertNever(language);
-  }
 };
 
 export const ResponsiveLayoutContainer: React.FC<Props> = ({ children }) => {
@@ -86,17 +38,15 @@ export const ResponsiveLayoutContainer: React.FC<Props> = ({ children }) => {
     }
   };
 
-  const terms = createTerms(snap.language);
+  const { language } = snap;
 
-  const privacy = createPrivacy(snap.language);
+  const { isLanguageMenuDisplayed } = snap;
 
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">
       <ResponsiveLayout
-        terms={terms}
-        privacy={privacy}
-        isLanguageMenuDisplayed={snap.isLanguageMenuDisplayed}
-        language={snap.language}
+        language={language}
+        isLanguageMenuDisplayed={isLanguageMenuDisplayed}
         onClickLanguageButton={onClickLanguageButton}
         onClickEn={onClickEn}
         onClickJa={onClickJa}

--- a/src/containers/ResponsiveLayoutContainer/ResponsiveLayoutContainer.tsx
+++ b/src/containers/ResponsiveLayoutContainer/ResponsiveLayoutContainer.tsx
@@ -25,22 +25,20 @@ const onClickJa = (event: React.MouseEvent<HTMLDivElement>) => {
 export const ResponsiveLayoutContainer: React.FC<Props> = ({ children }) => {
   const snap = useSnapshot(headerStateSelector());
 
+  const { language, isLanguageMenuDisplayed } = snap;
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onClickLanguageButton = (event: React.MouseEvent<HTMLDivElement>) => {
-    updateIsLanguageMenuDisplayed(!snap.isLanguageMenuDisplayed);
+    updateIsLanguageMenuDisplayed(!isLanguageMenuDisplayed);
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onClickOutSideMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     // メニューの外側をクリックしたときだけメニューを閉じる
-    if (snap.isLanguageMenuDisplayed) {
+    if (isLanguageMenuDisplayed) {
       updateIsLanguageMenuDisplayed(false);
     }
   };
-
-  const { language } = snap;
-
-  const { isLanguageMenuDisplayed } = snap;
 
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">

--- a/src/features/__tests__/termsOfUse/createLinksFromLanguages.spec.ts
+++ b/src/features/__tests__/termsOfUse/createLinksFromLanguages.spec.ts
@@ -1,0 +1,25 @@
+import { createLinksFromLanguages } from '../../termsOfUse';
+
+describe('src/features/termsOfUse.ts createLinksFromLanguages TestCase', () => {
+  it('should return an English link', () => {
+    const language = 'en';
+
+    const expected = {
+      text: 'Terms of Use',
+      link: '/terms',
+    };
+
+    expect(createLinksFromLanguages(language)).toStrictEqual(expected);
+  });
+
+  it('should return a Japanese link', () => {
+    const language = 'ja';
+
+    const expected = {
+      text: '利用規約',
+      link: '/terms',
+    };
+
+    expect(createLinksFromLanguages(language)).toStrictEqual(expected);
+  });
+});

--- a/src/features/termsOfUse.ts
+++ b/src/features/termsOfUse.ts
@@ -1,0 +1,22 @@
+import { Language } from '../types/language';
+import { LinkAttribute } from '../types/link';
+import assertNever from '../utils/assertNever';
+
+export const createLinksFromLanguages = (language: Language): LinkAttribute => {
+  const link = '/terms';
+
+  switch (language) {
+    case 'en':
+      return {
+        text: 'Terms of Use',
+        link,
+      };
+    case 'ja':
+      return {
+        text: '利用規約',
+        link,
+      };
+    default:
+      return assertNever(language);
+  }
+};

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
@@ -17,8 +17,6 @@ const ContentsWrapper = styled.div`
 export type Props = FooterProps & HeaderProps & { children: React.ReactNode };
 
 export const ResponsiveLayout: React.FC<Props> = ({
-  terms,
-  privacy,
   language,
   isLanguageMenuDisplayed,
   onClickLanguageButton,
@@ -35,6 +33,6 @@ export const ResponsiveLayout: React.FC<Props> = ({
       onClickJa={onClickJa}
     />
     <ContentsWrapper>{children}</ContentsWrapper>
-    <Footer terms={terms} privacy={privacy} />
+    <Footer language={language} />
   </Wrapper>
 );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/78

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/78 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-ohyuseajzv.chromatic.com/?path=/story/src-containers-responsivelayoutcontainer-responsivelayoutcontainer-tsx--default

# 変更点概要

Footerのテキストは言語情報から内部で生成するように変更。

これで基本的に全てのComponentが言語情報からテキストを切り替えるようになった。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
