### PR TITLE
アップロードファイルを選択する為のButtonをinputタグに変更

### DIFF
--- a/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
+++ b/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
@@ -7,6 +7,9 @@ type Props = {
 };
 
 const StyledUploadErrorMessageArea = styled.div`
+  @media (max-width: 767px) {
+    width: 389px;
+  }
   box-sizing: border-box;
   display: flex;
   flex: none;
@@ -36,6 +39,9 @@ const faExclamationTriangleStyle = {
 };
 
 const MessageText = styled.p`
+  @media (max-width: 767px) {
+    width: 389px;
+  }
   flex: none;
   flex-grow: 0;
   order: 1;

--- a/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
+++ b/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 const StyledUploadErrorMessageArea = styled.div`
   @media (max-width: 767px) {
-    width: 389px;
+    width: 380px;
   }
   box-sizing: border-box;
   display: flex;
@@ -40,7 +40,7 @@ const faExclamationTriangleStyle = {
 
 const MessageText = styled.p`
   @media (max-width: 767px) {
-    width: 389px;
+    width: 380px;
   }
   flex: none;
   flex-grow: 0;

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -23,9 +23,13 @@ const Wrapper = styled.div`
 `;
 
 const Form = styled.form`
+  @media (max-width: 767px) {
+    width: 380px;
+  }
   flex: none;
   flex-grow: 0;
   order: 1;
+  width: 500px;
 `;
 
 const InputFileArea = styled.div`

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -60,6 +60,10 @@ const Text = styled.div`
 `;
 
 const InputFile = styled.input`
+  display: none;
+`;
+
+const InputFileLabel = styled.label`
   top: 0;
   right: 0;
   bottom: 0;
@@ -73,12 +77,13 @@ const InputFile = styled.input`
   height: 43px;
   padding: 12px 20px;
   margin: auto;
+  cursor: pointer;
   background: #faf9f7;
   border: 1px solid #8e7e78;
   border-radius: 4px;
 `;
 
-const InputFileLabel = styled.label`
+const InputFileLabelText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -257,7 +262,9 @@ export const UploadForm: FC<Props> = ({ language, errorMessages }) => (
         <FaCloudUploadAlt style={faCloudUploadAltStyle} />
         <Text>{imageDropAreaText(language)}</Text>
         <InputFileLabel>
-          {uploadInputButtonText(language)}
+          <InputFileLabelText>
+            {uploadInputButtonText(language)}
+          </InputFileLabelText>
           <InputFile type="file" />
         </InputFileLabel>
       </InputFileArea>

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -258,7 +258,7 @@ export const UploadForm: FC<Props> = ({ language, errorMessages }) => (
         <Text>{imageDropAreaText(language)}</Text>
         <InputFileLabel>
           {uploadInputButtonText(language)}
-          <InputFile />
+          <InputFile type="file" />
         </InputFileLabel>
       </InputFileArea>
       <MaxUploadSizeText>Maximum upload size is 4MB</MaxUploadSizeText>

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -59,7 +59,7 @@ const Text = styled.div`
   text-align: center;
 `;
 
-const Button = styled.button`
+const InputFile = styled.input`
   top: 0;
   right: 0;
   bottom: 0;
@@ -78,7 +78,7 @@ const Button = styled.button`
   border-radius: 4px;
 `;
 
-const ButtonText = styled.div`
+const InputFileLabel = styled.label`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -256,9 +256,10 @@ export const UploadForm: FC<Props> = ({ language, errorMessages }) => (
       <InputFileArea>
         <FaCloudUploadAlt style={faCloudUploadAltStyle} />
         <Text>{imageDropAreaText(language)}</Text>
-        <Button>
-          <ButtonText>{uploadInputButtonText(language)}</ButtonText>
-        </Button>
+        <InputFileLabel>
+          {uploadInputButtonText(language)}
+          <InputFile />
+        </InputFileLabel>
       </InputFileArea>
       <MaxUploadSizeText>Maximum upload size is 4MB</MaxUploadSizeText>
       <DescriptionAreaWrapper>


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/46

# Done の定義

- アップロードフォームのファイル選択Buttonがinputタグで構成されファイルがアップロードできるようになっている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-hzjazjmgoa.chromatic.com/?path=/story/src-components-upload-uploadform-uploadform-tsx--view-in-english&globals=backgrounds.grid:false

# 変更点概要

表題の通りでButtonタグで構成されていたファイルの選択Buttonをinputタグで構成するように変更。

`<input>` 自体にCSSを当てる方法は上手くいかなかったので、`<label>` と `<div>` で構成して、 `<input>` タグを非表示にする事で対応。

また日本語と英語でフォームの幅が異なったり、スマホビューで見た時のエラーメッセージ表示エリアが崩れていたのでそれも修正を行った。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
