### PR TITLE
Modalの多言語化対応

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ coverage/
 .eslintrc.js
 *.config.js
 __mocks__/
+storybook-static/

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,7 +6,7 @@ jobs:
   chromatic-deployment:
     name: Deploy Storybook to chromatic
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: Build And Test
     runs-on: ubuntu-latest
+    timeout-minutes: 7
     strategy:
       matrix:
         node-version: [16.x]

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -20,6 +21,7 @@ jobs:
   publish-gpr:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # Optional stylelint cache
 .stylelintcache
+
+# Storybook
+storybook-static/

--- a/src/components/Upload/UploadModal/ButtonGroup.tsx
+++ b/src/components/Upload/UploadModal/ButtonGroup.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { Language } from '../../../types/language';
+import assertNever from '../../../utils/assertNever';
+
 const Wrapper = styled.div`
   display: flex;
   flex: none;
@@ -79,21 +82,45 @@ const UploadButtonText = styled.div`
   }
 `;
 
+const cancelButtonText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return 'キャンセル';
+    case 'en':
+      return 'cancel';
+    default:
+      return assertNever(language);
+  }
+};
+
+const uploadButtonText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return 'アップロード';
+    case 'en':
+      return 'upload';
+    default:
+      return assertNever(language);
+  }
+};
+
 type Props = {
+  language: Language;
   onClickUpload: () => Promise<void>;
   onClickCancel: () => void;
 };
 
 export const ButtonGroup: React.FC<Props> = ({
+  language,
   onClickUpload,
   onClickCancel,
 }) => (
   <Wrapper>
     <CancelButton onClick={onClickCancel}>
-      <CancelButtonText>キャンセル</CancelButtonText>
+      <CancelButtonText>{cancelButtonText(language)}</CancelButtonText>
     </CancelButton>
     <UploadButton onClick={onClickUpload}>
-      <UploadButtonText>アップロード</UploadButtonText>
+      <UploadButtonText>{uploadButtonText(language)}</UploadButtonText>
     </UploadButton>
   </Wrapper>
 );

--- a/src/components/Upload/UploadModal/SuccessMessageArea.tsx
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.tsx
@@ -4,7 +4,9 @@ import styled from 'styled-components';
 import { AppUrl, defaultAppUrl } from '../../../constants/url';
 import useClipboardMarkdown from '../../../hooks/useClipboardMarkdown';
 import { useCopySuccess } from '../../../hooks/useCopySuccess';
+import { Language } from '../../../types/language';
 import { LgtmImageUrl } from '../../../types/lgtmImage';
+import assertNever from '../../../utils/assertNever';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
 
 const Wrapper = styled.div`
@@ -172,7 +174,67 @@ const MarkdownSourceCopyButtonText = styled.div`
   color: #fff;
 `;
 
+const titleText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return 'アップロードが成功しました🐱！';
+    case 'en':
+      return 'Upload succeeded🐱!';
+    default:
+      return assertNever(language);
+  }
+};
+
+const closeButtonText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return '閉じる';
+    case 'en':
+      return 'close';
+    default:
+      return assertNever(language);
+  }
+};
+
+const markdownSourceCopyButtonText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return 'Markdownソースをコピー';
+    case 'en':
+      return 'Copy Markdown source';
+    default:
+      return assertNever(language);
+  }
+};
+
+const mainMessageText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return `LGTM画像を作成しているので少々お待ち下さい。「${markdownSourceCopyButtonText(
+        language,
+      )}」ボタンか上の画像をクリックするとMarkdownソースがコピーされます。`;
+    case 'en':
+      return `Please wait a moment while we create the LGTM image. Click on the "${markdownSourceCopyButtonText(
+        language,
+      )}" button or the image above to copy the Markdown source.`;
+    default:
+      return assertNever(language);
+  }
+};
+
+const descriptionText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return '※トップページの「New arrival Cats」ボタンを押下するとアップロードした画像を確認できます。';
+    case 'en':
+      return '※Click the "New arrival Cats" button on the top page to see the uploaded images.';
+    default:
+      return assertNever(language);
+  }
+};
+
 type Props = {
+  language: Language;
   createdLgtmImageUrl: LgtmImageUrl | string;
   onClickClose?: () => void;
   appUrl?: AppUrl;
@@ -180,6 +242,7 @@ type Props = {
 };
 
 export const SuccessMessageArea: React.FC<Props> = ({
+  language,
   createdLgtmImageUrl,
   onClickClose,
   appUrl,
@@ -195,27 +258,20 @@ export const SuccessMessageArea: React.FC<Props> = ({
 
   return (
     <Wrapper>
-      <Title>アップロードに成功しました🐱！</Title>
+      <Title>{titleText(language)}</Title>
       <ContentsWrapper>
-        <MainMessage>
-          LGTM画像を作成しているので少々お待ち下さい。
-          「Markdownソースをコピー」ボタンか上の画像を
-          クリックするとMarkdownソースがコピーされます。
-        </MainMessage>
+        <MainMessage>{mainMessageText(language)}</MainMessage>
         <UnderSectionWrapper>
           <DescriptionWrapper>
-            <DescriptionText>
-              ※トップページの「New arrival
-              Cats」ボタンを押下するとアップロードした画像を確認できます。
-            </DescriptionText>
+            <DescriptionText>{descriptionText(language)}</DescriptionText>
           </DescriptionWrapper>
           <ButtonGroup>
             <CloseButton onClick={onClickClose}>
-              <CloseButtonText>閉じる</CloseButtonText>
+              <CloseButtonText>{closeButtonText(language)}</CloseButtonText>
             </CloseButton>
             <MarkdownSourceCopyButton ref={imageContextRef}>
               <MarkdownSourceCopyButtonText>
-                Markdownソースをコピー
+                {markdownSourceCopyButtonText(language)}
               </MarkdownSourceCopyButtonText>
             </MarkdownSourceCopyButton>
           </ButtonGroup>

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -206,7 +206,7 @@ export const UploadModal: FC<Props> = ({
           ) : (
             ''
           )}
-          {isLoading ? <UploadProgressBar /> : ''}
+          {isLoading ? <UploadProgressBar language={language} /> : ''}
         </ContentsWrapper>
       </Wrapper>
     </Modal>

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -190,6 +190,7 @@ export const UploadModal: FC<Props> = ({
           </FormWrapper>
           {uploaded && createdLgtmImageUrl && !isLoading ? (
             <SuccessMessageArea
+              language={language}
               createdLgtmImageUrl={createdLgtmImageUrl}
               onClickClose={onClickClose}
             />

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { Language } from '../../../types/language';
 import { LgtmImageUrl } from '../../../types/lgtmImage';
+import assertNever from '../../../utils/assertNever';
 import { UploadProgressBar } from '../UploadProgressBar';
 
 import { ButtonGroup } from './ButtonGroup';
@@ -102,6 +103,28 @@ const ConfirmMessage = styled.div`
   color: #8e7e78;
 `;
 
+const titleText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return '猫ちゃん画像アップロード確認';
+    case 'en':
+      return 'Cat image upload confirmed';
+    default:
+      return assertNever(language);
+  }
+};
+
+const confirmMessageText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return 'この画像をアップロードします。よろしいですか？';
+    case 'en':
+      return 'Upload this image. Are you sure?';
+    default:
+      return assertNever(language);
+  }
+};
+
 const modalStyle = {
   // stylelint-disable-next-line
   overlay: {
@@ -121,7 +144,6 @@ const modalStyle = {
 // eslint-disable-next-line max-lines-per-function
 export const UploadModal: FC<Props> = ({
   isOpen,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   language,
   imagePreviewUrl,
   onClickUpload,
@@ -146,7 +168,7 @@ export const UploadModal: FC<Props> = ({
     >
       <Wrapper>
         <ContentsWrapper>
-          <Title>猫ちゃん画像アップロード確認</Title>
+          <Title>{titleText(language)}</Title>
           <FormWrapper>
             {uploaded ? (
               // TODO 後でちゃんとパラメータを渡せるようにする
@@ -161,9 +183,7 @@ export const UploadModal: FC<Props> = ({
             )}
             {!isLoading && !uploaded ? (
               <>
-                <ConfirmMessage>
-                  この画像をアップロードします。よろしいですか？
-                </ConfirmMessage>
+                <ConfirmMessage>{confirmMessageText(language)}</ConfirmMessage>
               </>
             ) : (
               ''

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -198,6 +198,7 @@ export const UploadModal: FC<Props> = ({
           )}
           {!uploaded && !createdLgtmImageUrl && !isLoading ? (
             <ButtonGroup
+              language={language}
               onClickUpload={onClickUpload}
               onClickCancel={onClickCancel}
             />

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -171,7 +171,6 @@ export const UploadModal: FC<Props> = ({
           <Title>{titleText(language)}</Title>
           <FormWrapper>
             {uploaded ? (
-              // TODO 後でちゃんとパラメータを渡せるようにする
               <CreatedLgtmImage
                 imagePreviewUrl={imagePreviewUrl}
                 createdLgtmImageUrl={createdLgtmImageUrl}

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.stories.tsx
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.stories.tsx
@@ -9,4 +9,10 @@ export default {
 
 type Story = ComponentStoryObj<typeof UploadProgressBar>;
 
-export const Default: Story = {};
+export const ViewInJapanese: Story = {
+  args: { language: 'ja' },
+};
+
+export const ViewInEnglish: Story = {
+  args: { language: 'en' },
+};

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { Language } from '../../../types/language';
+import assertNever from '../../../utils/assertNever';
+
 const Wrapper = styled.div`
   flex: none;
   flex-grow: 0;
@@ -39,7 +42,22 @@ const Message = styled.p`
   color: #8e7e78;
 `;
 
-export const UploadProgressBar: React.FC = () => {
+const messageText = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return '送信中…';
+    case 'en':
+      return 'Uploading…';
+    default:
+      return assertNever(language);
+  }
+};
+
+type Props = {
+  language: Language;
+};
+
+export const UploadProgressBar: React.FC<Props> = ({ language }) => {
   const minWidth = 1;
 
   const maxWidth = 279;
@@ -68,7 +86,7 @@ export const UploadProgressBar: React.FC = () => {
           <MainColorBar style={{ width: `${progressLength}px` }} />
         </DefaultColorBar>
       </BarWrapper>
-      <Message>送信中…</Message>
+      <Message>{messageText(language)}</Message>
     </Wrapper>
   );
 };


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/46

# Done の定義

- `UploadModal` の多言語化対応が実施されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-ulbfhluzfe.chromatic.com/?path=/story/src-components-upload-uploadmodal-uploadmodal-tsx--view-in-english-upload-successful

# 変更点概要

`UploadModal` に `language` を渡せるようにして、それに合わせた言語でテキストを表示させるようにした。

# レビュアーに重点的にチェックして欲しい点

英語の翻訳が適切かどうか確認してもらえると:pray:

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
