### PR TITLE
Modalを閉じる時の動作を統一

### DIFF
--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -116,6 +116,8 @@ export const UploadForm: FC<Props> = ({
   };
 
   const closeModal = () => {
+    setUploaded(false);
+    setCreatedLgtmImageUrl('');
     setModalIsOpen(false);
   };
 
@@ -226,10 +228,6 @@ export const UploadForm: FC<Props> = ({
 
   const onClickClose = () => {
     closeModal();
-
-    setImagePreviewUrl('');
-    setCreatedLgtmImageUrl('');
-    setUploaded(false);
   };
 
   return (


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/46

# Done の定義

- Modalと閉じた際の挙動がキャンセルボタンの押下時とModal要素外を押下時で統一されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-spmxpcxgiz.chromatic.com/?path=/story/src-components-upload-uploadform-uploadform-tsx--view-in-japanese

# 変更点概要

Modalを閉じた際に `uploaded` と `createdLgtmImageUrl` を無効化するようにした。

これによって同じ画像を連続で上げやすくなったが、Modalを挟んでいるので、そこは許容する事にした。

Modalを閉じる際に全てのパラメータをリセットする方法もあるが、そうするとModalを閉じた後に同じ画像をアップロードしようとすると下記の問題が発生していまい、ユーザーがページリロードを行う以外に手段がなくなってしまう。

https://github.com/nekochans/lgtm-cat-frontend/issues/152

このPRの仕様だとアップロードボタンを押下すれば回避出来るので、今はこの形で進めてみる。

# レビュアーに重点的にチェックして欲しい点

アップロードのフローに問題がないか確認してもらえると:pray:

# 補足情報

`onClickCancel`, `onClickClose` はもはや全く同じ内容になってしまっているが、GAなどでイベントを送信する際に分かれていたほうが良いので今はこのままにしてある。

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
