### PR TITLE
ソースマップを無効化

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,20 +15,20 @@ export default [
       {
         file: packageJson.main,
         format: 'cjs',
-        sourcemap: true,
+        sourcemap: false,
         name: 'lgtm-cat-ui',
       },
       {
         file: packageJson.module,
         format: 'esm',
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [
       external(),
       resolve(),
       commonjs(),
-      typescript({ tsconfig: './tsconfig.json' }),
+      typescript({ tsconfig: './tsconfig.build.json' }),
       postcss(),
       image(),
     ],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  }
+}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/81

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/81 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-thechlpcpa.chromatic.com/

# 変更点概要

本番Build時のソースマップを無効化。

これによってPackageの配布サイズが大幅に小さくなる。

`rollup.config.js` の設定を変えるだけでは駄目で、`tsconfig.json` にも `"sourceMap": true,` の指定が必要だった。

開発中はソースマップがあったほうが良いので、`tsconfig.build.json` を新しく作成する対応を行った。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
