### PR TITLE
各ComponentではReactの型定義のみをexportするように変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/AppDescriptionArea/AppDescriptionArea.tsx
+++ b/src/components/AppDescriptionArea/AppDescriptionArea.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { Language } from '../../types/language';
 import assertNever from '../../utils/assertNever';
+
+import type { FC } from 'react';
 
 const Wrapper = styled.div``;
 
@@ -38,21 +39,21 @@ export type Props = {
   language: Language;
 };
 
-const JaAppDescriptionArea: React.FC = () => (
+const JaAppDescriptionArea: FC = () => (
   <Wrapper>
     <JaText>{jaUpperSectionText}</JaText>
     <JaText>{jaLowerSectionText}</JaText>
   </Wrapper>
 );
 
-const EnAppDescriptionArea: React.FC = () => (
+const EnAppDescriptionArea: FC = () => (
   <Wrapper>
     <EnText>{enUpperSectionText}</EnText>
     <EnText>{enLowerSectionText}</EnText>
   </Wrapper>
 );
 
-export const AppDescriptionArea: React.FC<Props> = ({ language }) => {
+export const AppDescriptionArea: FC<Props> = ({ language }) => {
   switch (language) {
     case 'ja':
       return <JaAppDescriptionArea />;

--- a/src/components/Button/BackToTopButton/BackToTopButton.tsx
+++ b/src/components/Button/BackToTopButton/BackToTopButton.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
-import React from 'react';
 import styled from 'styled-components';
+
+import type { FC } from 'react';
 
 const StyledSpan = styled.span`
   display: flex;
@@ -38,7 +39,7 @@ type Props = {
   text: string;
 };
 
-export const BackToTopButton: React.FC<Props> = ({ text }) => (
+export const BackToTopButton: FC<Props> = ({ text }) => (
   <Link href="/" prefetch={false}>
     <StyledSpan>
       <Text>{text}</Text>

--- a/src/components/Button/CatButtonGroup/CatButtonGroup.tsx
+++ b/src/components/Button/CatButtonGroup/CatButtonGroup.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { CatFetchButton } from '../CatFetchButton';
 import { UploadCatButton } from '../UploadCatButton';
+
+import type { FC } from 'react';
 
 const Wrapper = styled.div`
   @media (max-width: 767px) {
@@ -30,7 +31,7 @@ const ButtonGroup = styled.div`
   padding: 0;
 `;
 
-export const CatButtonGroup = () => (
+export const CatButtonGroup: FC = () => (
   <Wrapper>
     <ButtonGroup>
       <UploadCatButton link="/upload" />

--- a/src/components/Button/CatFetchButton/CatFetchButton.tsx
+++ b/src/components/Button/CatFetchButton/CatFetchButton.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
 import { FaSyncAlt } from 'react-icons/fa';
 import styled from 'styled-components';
 
 import { mixins } from '../../../styles/mixins';
 import assertNever from '../../../utils/assertNever';
+
+import type { FC } from 'react';
 
 const StyledButton = styled.button`
   background: #eb7c06;
@@ -42,7 +43,7 @@ type Props = {
   type: ButtonType;
 };
 
-export const CatFetchButton: React.FC<Props> = ({ type }) => (
+export const CatFetchButton: FC<Props> = ({ type }) => (
   <StyledButton>
     <FaSyncAlt style={faSyncAltStyle} />
     <Text>{buttonText(type)}</Text>

--- a/src/components/Button/GitHubLoginButton/GitHubLoginButton.tsx
+++ b/src/components/Button/GitHubLoginButton/GitHubLoginButton.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import { FaGithub } from 'react-icons/fa';
 import styled from 'styled-components';
 
 import { mixins } from '../../../styles/mixins';
+
+import type { FC } from 'react';
 
 const StyledGitHubLoginButton = styled.button`
   background: #eb7c06;
@@ -24,7 +25,7 @@ const faGithubStyle = {
   flexGrow: 0,
 };
 
-export const GitHubLoginButton: React.FC = () => (
+export const GitHubLoginButton: FC = () => (
   <StyledGitHubLoginButton>
     <FaGithub style={faGithubStyle} />
     <Text>Login</Text>

--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link';
-import React from 'react';
 import { FaCloudUploadAlt } from 'react-icons/fa';
 import styled from 'styled-components';
 
 import { mixins } from '../../../styles/mixins';
 
 import slash from './slash.png';
+
+import type { FC } from 'react';
 
 const StyledSpan = styled.span`
   background: #eb7c06 url(${slash.src}) repeat 0 0/16px auto;
@@ -31,7 +32,7 @@ type Props = {
   link: `/${string}`;
 };
 
-export const UploadCatButton: React.FC<Props> = ({ link }) => (
+export const UploadCatButton: FC<Props> = ({ link }) => (
   <Link href={link} prefetch={false}>
     <StyledSpan>
       <FaCloudUploadAlt style={faCloudUploadAltStyle} />

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link';
-import React from 'react';
 import styled from 'styled-components';
 
 import { createLinksFromLanguages as createPrivacyLinksFromLanguages } from '../../features/privacyPolicy';
 import { createLinksFromLanguages as createTermsLinksFromLanguages } from '../../features/termsOfUse';
 import { Language } from '../../types/language';
+
+import type { FC } from 'react';
 
 const StyledFooter = styled.div`
   position: relative;
@@ -106,7 +107,7 @@ export type Props = {
   language: Language;
 };
 
-export const Footer: React.FC<Props> = ({ language }) => {
+export const Footer: FC<Props> = ({ language }) => {
   const terms = createTermsLinksFromLanguages(language);
 
   const privacy = createPrivacyLinksFromLanguages(language);

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
 import { FaBars } from 'react-icons/fa';
 import styled from 'styled-components';
 
 import { LanguageButton } from './LanguageButton';
 import { LanguageMenu, Props as LanguageMenuProps } from './LanguageMenu';
+
+import type { FC, MouseEvent } from 'react';
 
 const Wrapper = styled.div`
   background: #e9e2d7;
@@ -51,10 +52,10 @@ const faBarsStyle = {
 
 export type Props = LanguageMenuProps & {
   isLanguageMenuDisplayed: boolean;
-  onClickLanguageButton: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onClickLanguageButton: (event: MouseEvent<HTMLDivElement>) => void;
 };
 
-export const Header: React.FC<Props> = ({
+export const Header: FC<Props> = ({
   language,
   isLanguageMenuDisplayed,
   onClickLanguageButton,

--- a/src/components/Header/LanguageButton.tsx
+++ b/src/components/Header/LanguageButton.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
 import { FaCaretDown } from 'react-icons/fa';
 import styled from 'styled-components';
+
+import type { FC, MouseEvent } from 'react';
 
 const Wrapper = styled.div`
   @media (max-width: 767px) {
@@ -38,10 +39,10 @@ const faCaretDownStyle = {
 };
 
 type Props = {
-  onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onClick: (event: MouseEvent<HTMLDivElement>) => void;
 };
 
-export const LanguageButton: React.FC<Props> = ({ onClick }) => (
+export const LanguageButton: FC<Props> = ({ onClick }) => (
   <Wrapper onClick={onClick}>
     <Text>Language</Text>
     <FaCaretDown style={faCaretDownStyle} />

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import { FaAngleRight } from 'react-icons/fa';
 import styled, { css } from 'styled-components';
 
 import { Language } from '../../types/language';
+
+import type { FC, MouseEvent } from 'react';
 
 const textWrapperStyle = css`
   display: flex;
@@ -83,15 +84,11 @@ const JaText = styled.div`
 
 export type Props = {
   language: Language;
-  onClickEn: (event: React.MouseEvent<HTMLDivElement>) => void;
-  onClickJa: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onClickEn: (event: MouseEvent<HTMLDivElement>) => void;
+  onClickJa: (event: MouseEvent<HTMLDivElement>) => void;
 };
 
-export const LanguageMenu: React.FC<Props> = ({
-  language,
-  onClickEn,
-  onClickJa,
-}) => (
+export const LanguageMenu: FC<Props> = ({ language, onClickEn, onClickJa }) => (
   <StyledLanguageMenu>
     <EnTextWrapper>
       <EnText onClick={onClickEn}>

--- a/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
+++ b/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import styled from 'styled-components';
+
+import type { FC } from 'react';
 
 const Wrapper = styled.div`
   position: absolute;
@@ -13,6 +14,6 @@ const Wrapper = styled.div`
   transform: translate(-50%, 0);
 `;
 
-export const CopiedGithubMarkdownMessage: React.FC = () => (
+export const CopiedGithubMarkdownMessage: FC = () => (
   <Wrapper>Github Markdown Copied!</Wrapper>
 );

--- a/src/components/LgtmImages/LgtmImageContent.tsx
+++ b/src/components/LgtmImages/LgtmImageContent.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import React from 'react';
 import styled from 'styled-components';
 
 import { AppUrl, defaultAppUrl } from '../../constants/url';
@@ -8,6 +7,8 @@ import { useCopySuccess } from '../../hooks/useCopySuccess';
 import { LgtmImage } from '../../types/lgtmImage';
 
 import { CopiedGithubMarkdownMessage } from './CopiedGithubMarkdownMessage';
+
+import type { FC } from 'react';
 
 const ImageWrapper = styled.div`
   position: relative;
@@ -23,7 +24,7 @@ type Props = LgtmImage & {
   callback?: () => void;
 };
 
-export const LgtmImageContent: React.FC<Props> = ({
+export const LgtmImageContent: FC<Props> = ({
   id,
   imageUrl,
   appUrl,

--- a/src/components/LgtmImages/LgtmImages.tsx
+++ b/src/components/LgtmImages/LgtmImages.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { AppUrl } from '../../constants/url';
 import { LgtmImage } from '../../types/lgtmImage';
 
 import { LgtmImageContent } from './LgtmImageContent';
+
+import type { FC } from 'react';
 
 const Wrapper = styled.div`
   @media (max-width: 767px) {
@@ -22,7 +23,7 @@ type Props = {
   callback?: () => void;
 };
 
-export const LgtmImages: React.FC<Props> = ({ images, appUrl, callback }) => (
+export const LgtmImages: FC<Props> = ({ images, appUrl, callback }) => (
   <Wrapper>
     {images.map((image) => (
       <LgtmImageContent

--- a/src/components/Upload/UploadButton/UploadButton.tsx
+++ b/src/components/Upload/UploadButton/UploadButton.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { Language } from '../../../types/language';
 import assertNever from '../../../utils/assertNever';
+
+import type { FC, FormEventHandler } from 'react';
 
 const buttonCss = css`
   display: flex;
@@ -73,14 +74,10 @@ const createText = (language: Language): string => {
 type Props = {
   language: Language;
   disabled: boolean;
-  onClick: React.FormEventHandler;
+  onClick: FormEventHandler;
 };
 
-export const UploadButton: React.FC<Props> = ({
-  language,
-  disabled,
-  onClick,
-}) => {
+export const UploadButton: FC<Props> = ({ language, disabled, onClick }) => {
   if (disabled === false) {
     return (
       <Button type="submit" disabled={disabled} onClick={onClick}>

--- a/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
+++ b/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
 import { FaExclamationTriangle } from 'react-icons/fa';
 import styled from 'styled-components';
+
+import type { FC } from 'react';
 
 type Props = {
   messages: string[];
@@ -56,7 +57,7 @@ const MessageText = styled.p`
   text-align: center;
 `;
 
-export const UploadErrorMessageArea: React.FC<Props> = ({ messages }) => (
+export const UploadErrorMessageArea: FC<Props> = ({ messages }) => (
   <StyledUploadErrorMessageArea>
     <FaExclamationTriangle style={faExclamationTriangleStyle} />
     <MessageText>

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import Link from 'next/link';
-import React, { ChangeEvent, type FC, useState } from 'react';
+import { useState, useCallback, type FC, FormEvent, ChangeEvent } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { FaCloudUploadAlt } from 'react-icons/fa';
 
@@ -188,7 +188,7 @@ export const UploadForm: FC<Props> = ({
     return imagePreviewUrl === '';
   };
 
-  const onClickUploadButton = (event: React.FormEvent<HTMLFormElement>) => {
+  const onClickUploadButton = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     openModal();
@@ -236,7 +236,7 @@ export const UploadForm: FC<Props> = ({
     closeModal();
   };
 
-  const onDrop = React.useCallback((acceptedFiles: File[]) => {
+  const onDrop = useCallback((acceptedFiles: File[]) => {
     // eslint-disable-next-line no-magic-numbers
     if (acceptedFiles && acceptedFiles.length > 0) {
       const targetIndex = 0;

--- a/src/components/Upload/UploadModal/ButtonGroup.tsx
+++ b/src/components/Upload/UploadModal/ButtonGroup.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { Language } from '../../../types/language';
 import assertNever from '../../../utils/assertNever';
+
+import type { FC } from 'react';
 
 const Wrapper = styled.div`
   display: flex;
@@ -110,7 +111,7 @@ type Props = {
   onClickCancel: () => void;
 };
 
-export const ButtonGroup: React.FC<Props> = ({
+export const ButtonGroup: FC<Props> = ({
   language,
   onClickUpload,
   onClickCancel,

--- a/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
+++ b/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { AppUrl, defaultAppUrl } from '../../../constants/url';
@@ -6,6 +5,8 @@ import useClipboardMarkdown from '../../../hooks/useClipboardMarkdown';
 import { useCopySuccess } from '../../../hooks/useCopySuccess';
 import { LgtmImageUrl } from '../../../types/lgtmImage';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
+
+import type { FC } from 'react';
 
 const Wrapper = styled.div`
   flex: none;
@@ -31,7 +32,7 @@ type Props = {
   callback?: () => void;
 };
 
-export const CreatedLgtmImage: React.FC<Props> = ({
+export const CreatedLgtmImage: FC<Props> = ({
   imagePreviewUrl,
   createdLgtmImageUrl,
   appUrl,

--- a/src/components/Upload/UploadModal/SuccessMessageArea.tsx
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { AppUrl, defaultAppUrl } from '../../../constants/url';
@@ -8,6 +7,8 @@ import { Language } from '../../../types/language';
 import { LgtmImageUrl } from '../../../types/lgtmImage';
 import assertNever from '../../../utils/assertNever';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
+
+import type { FC } from 'react';
 
 const Wrapper = styled.div`
   display: flex;
@@ -241,7 +242,7 @@ type Props = {
   callback?: () => void;
 };
 
-export const SuccessMessageArea: React.FC<Props> = ({
+export const SuccessMessageArea: FC<Props> = ({
   language,
   createdLgtmImageUrl,
   onClickClose,

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -1,4 +1,3 @@
-import React, { FC } from 'react';
 import Modal from 'react-modal';
 import styled from 'styled-components';
 
@@ -10,6 +9,8 @@ import { UploadProgressBar } from '../UploadProgressBar';
 import { ButtonGroup } from './ButtonGroup';
 import { CreatedLgtmImage } from './CreatedLgtmImage';
 import { SuccessMessageArea } from './SuccessMessageArea';
+
+import type { FC } from 'react';
 
 export type Props = {
   isOpen: boolean;

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState, useEffect, type FC } from 'react';
 import styled from 'styled-components';
 
 import { Language } from '../../../types/language';
@@ -57,7 +57,7 @@ type Props = {
   language: Language;
 };
 
-export const UploadProgressBar: React.FC<Props> = ({ language }) => {
+export const UploadProgressBar: FC<Props> = ({ language }) => {
   const minWidth = 1;
 
   const maxWidth = 279;
@@ -66,9 +66,9 @@ export const UploadProgressBar: React.FC<Props> = ({ language }) => {
 
   const interval = 200;
 
-  const [progressLength, setProgressLength] = React.useState<number>(minWidth);
+  const [progressLength, setProgressLength] = useState<number>(minWidth);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const id = setInterval(() => {
       const updatedWidth =
         progressLength <= maxWidth ? progressLength + incrementValue : minWidth;

--- a/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
+++ b/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { Language } from '../../../types/language';
 import assertNever from '../../../utils/assertNever';
+
+import type { FC } from 'react';
 
 const StyledUploadTitleArea = styled.div`
   font-family: Roboto, sans-serif;
@@ -32,6 +33,6 @@ const text = (language: Language): Text => {
   }
 };
 
-export const UploadTitleArea: React.FC<Props> = ({ language }) => (
+export const UploadTitleArea: FC<Props> = ({ language }) => (
   <StyledUploadTitleArea>{text(language)}</StyledUploadTitleArea>
 );

--- a/src/containers/ResponsiveLayoutContainer/ResponsiveLayoutContainer.stories.tsx
+++ b/src/containers/ResponsiveLayoutContainer/ResponsiveLayoutContainer.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { LgtmImages } from '../../components';
 import { AppDescriptionArea } from '../../components/AppDescriptionArea';
 import { CatButtonGroup } from '../../components/Button/CatButtonGroup';
@@ -8,6 +6,7 @@ import { LgtmImage } from '../../types/lgtmImage';
 import { ResponsiveLayoutContainer } from './.';
 
 import type { ComponentStoryObj, Meta } from '@storybook/react';
+import type { FC } from 'react';
 
 export default {
   title:
@@ -17,7 +16,7 @@ export default {
 
 type Story = ComponentStoryObj<typeof ResponsiveLayoutContainer>;
 
-const JpContents: React.FC = () => (
+const JpContents: FC = () => (
   <>
     <h1>タイトル</h1>
     <h2>サブタイトル</h2>

--- a/src/containers/ResponsiveLayoutContainer/ResponsiveLayoutContainer.tsx
+++ b/src/containers/ResponsiveLayoutContainer/ResponsiveLayoutContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useSnapshot } from 'valtio';
 
 import { ResponsiveLayout } from '../../layouts';
@@ -8,32 +7,34 @@ import {
   updateLanguage,
 } from '../../stores/valtio/header';
 
+import type { FC, ReactNode, MouseEvent } from 'react';
+
 type Props = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const onClickEn = (event: React.MouseEvent<HTMLDivElement>) => {
+const onClickEn = (event: MouseEvent<HTMLDivElement>) => {
   updateLanguage('en');
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const onClickJa = (event: React.MouseEvent<HTMLDivElement>) => {
+const onClickJa = (event: MouseEvent<HTMLDivElement>) => {
   updateLanguage('ja');
 };
 
-export const ResponsiveLayoutContainer: React.FC<Props> = ({ children }) => {
+export const ResponsiveLayoutContainer: FC<Props> = ({ children }) => {
   const snap = useSnapshot(headerStateSelector());
 
   const { language, isLanguageMenuDisplayed } = snap;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onClickLanguageButton = (event: React.MouseEvent<HTMLDivElement>) => {
+  const onClickLanguageButton = (event: MouseEvent<HTMLDivElement>) => {
     updateIsLanguageMenuDisplayed(!isLanguageMenuDisplayed);
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onClickOutSideMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+  const onClickOutSideMenu = (event: MouseEvent<HTMLDivElement>) => {
     // メニューの外側をクリックしたときだけメニューを閉じる
     if (isLanguageMenuDisplayed) {
       updateIsLanguageMenuDisplayed(false);

--- a/src/hooks/useCopySuccess.ts
+++ b/src/hooks/useCopySuccess.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState, useCallback } from 'react';
 
 type Response = {
   copied: boolean;
@@ -6,9 +6,9 @@ type Response = {
 };
 
 export const useCopySuccess = (callback?: () => void): Response => {
-  const [copied, setCopied] = React.useState(false);
+  const [copied, setCopied] = useState(false);
 
-  const onCopySuccess = React.useCallback(() => {
+  const onCopySuccess = useCallback(() => {
     if (callback) {
       callback();
     }

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.stories.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-
 import { ResponsiveLayout } from './';
 
 import type { ComponentStoryObj, Meta } from '@storybook/react';
+import type { FC } from 'react';
 
 export default {
   title: 'src/layouts/ResponsiveLayout/ResponsiveLayout.tsx',
@@ -11,7 +10,7 @@ export default {
 
 type Story = ComponentStoryObj<typeof ResponsiveLayout>;
 
-const JpContents: React.FC = () => (
+const JpContents: FC = () => (
   <>
     <h1>タイトル</h1>
     <h2>サブタイトル</h2>
@@ -19,7 +18,7 @@ const JpContents: React.FC = () => (
   </>
 );
 
-const EnContents: React.FC = () => (
+const EnContents: FC = () => (
   <>
     <h1>Title</h1>
     <h2>SubTitle</h2>

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { Footer, Props as FooterProps } from '../../components/Footer';
 import { Header, Props as HeaderProps } from '../../components/Header';
+
+import type { FC, ReactNode } from 'react';
 
 const Wrapper = styled.div`
   position: relative;
@@ -14,9 +15,9 @@ const ContentsWrapper = styled.div`
   text-align: center;
 `;
 
-export type Props = FooterProps & HeaderProps & { children: React.ReactNode };
+export type Props = FooterProps & HeaderProps & { children: ReactNode };
 
-export const ResponsiveLayout: React.FC<Props> = ({
+export const ResponsiveLayout: FC<Props> = ({
   language,
   isLanguageMenuDisplayed,
   onClickLanguageButton,

--- a/src/templates/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import React from 'react';
 import styled from 'styled-components';
 
 import { BackToTopButton } from '../../components/Button/BackToTopButton';
@@ -9,6 +8,8 @@ import assertNever from '../../utils/assertNever';
 import internalServerError from './images/internal_server_error.webp';
 import notFound from './images/not_found.webp';
 import serviceUnavailable from './images/service_unavailable.webp';
+
+import type { FC } from 'react';
 
 const Wrapper = styled.div`
   display: flex;
@@ -209,7 +210,7 @@ type Props = {
   language: Language;
 };
 
-export const ErrorTemplate: React.FC<Props> = ({ type, language }) => (
+export const ErrorTemplate: FC<Props> = ({ type, language }) => (
   <Wrapper>
     <Title>{createErrorTitleText(type)}</Title>
     {createErrorImage(type)}

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react';
 
 import { ResponsiveLayoutContainer } from '../../containers';
 import { createSuccessResult } from '../../features/result';
@@ -9,6 +8,7 @@ import { sleep } from '../../utils/sleep';
 import { UploadTemplate, Props } from '.';
 
 import type { ComponentStoryObj, Meta } from '@storybook/react';
+import type { FC } from 'react';
 
 const imageValidator = async (
   image: string,
@@ -35,7 +35,7 @@ const imageUploader = async (
   });
 };
 
-const UploadTemplateWithResponsiveLayout: React.FC<Props> = ({ language }) => (
+const UploadTemplateWithResponsiveLayout: FC<Props> = ({ language }) => (
   <ResponsiveLayoutContainer>
     <UploadTemplate
       language={language}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "sourceMap": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "esnext",
-    "jsx": "react",
+    "jsx": "react-jsxdev",
     "sourceMap": true,
     "outDir": "dist",
     "strict": true,


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/73

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/73 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-wdgvipkizc.chromatic.com/

# 変更点概要

React17以降は `import React from 'react';` の記述を不要に出来るので、 `compilerOptions.jsx` を変更する事で対応。

基本的には各ファイルでは必要な型定義だけをimportするように改修。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の記事を参考にした。

https://zenn.dev/uhyo/articles/react17-new-jsx-transform#typescript%E3%81%AE%E8%A8%AD%E5%AE%9A

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
