### PR TITLE
構造的にTermsOrPrivacyTemplateをexportする事は難しいので一部のhooksとLayoutをexportするように変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.18.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useSwitchLanguage } from './useSwitchLanguage';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export * from './components';
 export * from './containers';
+export * from './hooks';
+export * from './layouts';
 export * from './templates';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/105

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/105 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-hxzrnzjbjm.chromatic.com

# 変更点概要

結論、`TermsOrPrivacyTemplate` のexportは諦めてLayoutやHooksを用いてPackage利用側で作成する方針とした。

この決断に至った経緯だが、まず `TermsOrPrivacyTemplate` がexport出来ない原因が https://github.com/remarkjs/react-markdown のREADMEにある通りこのPackageがESModule専用である事。

>This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). In Node.js (version 12.20+, 14.14+, or 16.0+), install with [npm](https://docs.npmjs.com/cli/install):

その為、現在のBuild設定では正常にBuildを行う事が出来ない。これらの設定を調査するのは非常に時間がかかりそうなので、最初は `TermsOrPrivacyTemplate` でChildrenでReactNodeを受け取る方法を考えたが、この設計だと言語を切り替えた際にMarkdownで書かれた本文を切り替える事が出来ないので、どちらにせよ `TermsOrPrivacyTemplate` をexportして利用する事は難しいと判断した。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
