### PR TITLE
UploadTemplateのねこ画像は外から渡すように変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -1,11 +1,19 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import Image from 'next/image';
+
 import { createSuccessResult } from '../../features/result';
 import { AcceptedTypesImageExtension } from '../../types/lgtmImage';
 import { sleep } from '../../utils/sleep';
 
+import cat from './images/cat.webp';
+
 import { UploadTemplate } from '.';
 
 import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+const CatImage = () => (
+  <Image src={cat.src} width="302px" height="302px" alt="Cat" priority={true} />
+);
 
 const imageValidator = async (
   image: string,
@@ -40,9 +48,19 @@ export default {
 type Story = ComponentStoryObj<typeof UploadTemplate>;
 
 export const ViewInJapanese: Story = {
-  args: { language: 'ja', imageValidator, imageUploader },
+  args: {
+    language: 'ja',
+    imageValidator,
+    imageUploader,
+    catImage: <CatImage />,
+  },
 };
 
 export const ViewInEnglish: Story = {
-  args: { language: 'en', imageValidator, imageUploader },
+  args: {
+    language: 'en',
+    imageValidator,
+    imageUploader,
+    catImage: <CatImage />,
+  },
 };

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -1,5 +1,3 @@
-import Image from 'next/image';
-import React, { FC } from 'react';
 import styled from 'styled-components';
 
 import { UploadForm } from '../../components';
@@ -8,7 +6,7 @@ import { ResponsiveLayout } from '../../layouts';
 import { Language } from '../../types/language';
 import { ImageUploader, ImageValidator } from '../../types/lgtmImage';
 
-import cat from './images/cat.webp';
+import type { FC, ReactNode } from 'react';
 
 const ImageWrapper = styled.div`
   display: flex;
@@ -19,28 +17,18 @@ const ImageWrapper = styled.div`
   }
 `;
 
-const CatImage = () => (
-  <ImageWrapper>
-    <Image
-      src={cat.src}
-      width="302px"
-      height="302px"
-      alt="Cat"
-      priority={true}
-    />
-  </ImageWrapper>
-);
-
 type Props = {
   language: Language;
   imageValidator: ImageValidator;
   imageUploader: ImageUploader;
+  catImage: ReactNode;
 };
 
 export const UploadTemplate: FC<Props> = ({
   language,
   imageValidator,
   imageUploader,
+  catImage,
 }) => {
   const {
     isLanguageMenuDisplayed,
@@ -65,7 +53,7 @@ export const UploadTemplate: FC<Props> = ({
           imageValidator={imageValidator}
           imageUploader={imageUploader}
         />
-        <CatImage />
+        <ImageWrapper>{catImage}</ImageWrapper>
       </ResponsiveLayout>
     </div>
   );

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { UploadForm } from '../../components';
-import { useSwitchLanguage } from '../../hooks/useSwitchLanguage';
+import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
 import { Language } from '../../types/language';
 import { ImageUploader, ImageValidator } from '../../types/lgtmImage';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/104

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/104 の現象が修正されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-subakiwadv.chromatic.com/?path=/story/src-templates-uploadtemplate-uploadtemplate-tsx--view-in-english

# 変更点概要

`next/image` を使っているせいか、Buildした結果に画像が含まれないので、確実に表示させるように外から渡すように変更。

Storybookを見るとPackage利用者がどのように使えば良いか分かるようになっている。

そしておそらくErrorTemplateのほうも同様の現象が起きているので、別PRで同じように修正する。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
