### PR TITLE
ErrorTemplateを完成系の形に改修

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
@@ -1,3 +1,9 @@
+import Image from 'next/image';
+
+import internalServerError from './images/internal_server_error.webp';
+import notFound from './images/not_found.webp';
+import serviceUnavailable from './images/service_unavailable.webp';
+
 import { ErrorTemplate } from './index';
 
 import type { ComponentStoryObj, Meta } from '@storybook/react';
@@ -9,10 +15,41 @@ export default {
 
 type Story = ComponentStoryObj<typeof ErrorTemplate>;
 
+const NotFoundImage = () => (
+  <Image
+    src={notFound.src}
+    layout="fill"
+    objectFit="contain"
+    alt="404 Not Found"
+    priority={true}
+  />
+);
+
+const InternalServerErrorImage = () => (
+  <Image
+    src={internalServerError.src}
+    layout="fill"
+    objectFit="contain"
+    alt="500 Internal Server Error"
+    priority={true}
+  />
+);
+
+const ServiceUnavailableImage = () => (
+  <Image
+    src={serviceUnavailable.src}
+    layout="fill"
+    objectFit="contain"
+    alt="503 Service Unavailable"
+    priority={true}
+  />
+);
+
 export const NotFoundViewInJapanese: Story = {
   args: {
     type: 404,
     language: 'ja',
+    catImage: <NotFoundImage />,
   },
 };
 
@@ -20,6 +57,7 @@ export const NotFoundViewInEnglish: Story = {
   args: {
     type: 404,
     language: 'en',
+    catImage: <NotFoundImage />,
   },
 };
 
@@ -27,6 +65,7 @@ export const InternalServerErrorViewInJapanese: Story = {
   args: {
     type: 500,
     language: 'ja',
+    catImage: <InternalServerErrorImage />,
   },
 };
 
@@ -34,6 +73,7 @@ export const InternalServerErrorViewInEnglish: Story = {
   args: {
     type: 500,
     language: 'en',
+    catImage: <InternalServerErrorImage />,
   },
 };
 
@@ -41,6 +81,7 @@ export const ServiceUnavailableViewInJapanese: Story = {
   args: {
     type: 503,
     language: 'ja',
+    catImage: <ServiceUnavailableImage />,
   },
 };
 
@@ -48,5 +89,6 @@ export const ServiceUnavailableViewInEnglish: Story = {
   args: {
     type: 503,
     language: 'en',
+    catImage: <ServiceUnavailableImage />,
   },
 };

--- a/src/templates/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.tsx
@@ -1,15 +1,13 @@
-import Image from 'next/image';
 import styled from 'styled-components';
 
+import { useSwitchLanguage } from '../../hooks';
+import { ResponsiveLayout } from '../../layouts';
 import { Language } from '../../types/language';
 import assertNever from '../../utils/assertNever';
 
 import { BackToTopButton } from './BackToTopButton';
-import internalServerError from './images/internal_server_error.webp';
-import notFound from './images/not_found.webp';
-import serviceUnavailable from './images/service_unavailable.webp';
 
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 
 const Wrapper = styled.div`
   display: flex;
@@ -69,55 +67,6 @@ const createErrorTitleText = (type: ErrorType): ErrorTitleText => {
       return errorTitleText.internalServerError;
     case errorType.serviceUnavailable:
       return errorTitleText.serviceUnavailable;
-    default:
-      return assertNever(type);
-  }
-};
-
-const NotFoundImage = () => (
-  <ImageWrapper>
-    <Image
-      src={notFound.src}
-      layout="fill"
-      objectFit="contain"
-      alt={errorTitleText.notFound}
-      priority={true}
-    />
-  </ImageWrapper>
-);
-
-const InternalServerErrorImage = () => (
-  <ImageWrapper>
-    <Image
-      src={internalServerError.src}
-      layout="fill"
-      objectFit="contain"
-      alt={errorTitleText.internalServerError}
-      priority={true}
-    />
-  </ImageWrapper>
-);
-
-const ServiceUnavailableImage = () => (
-  <ImageWrapper>
-    <Image
-      src={serviceUnavailable.src}
-      layout="fill"
-      objectFit="contain"
-      alt={errorTitleText.serviceUnavailable}
-      priority={true}
-    />
-  </ImageWrapper>
-);
-
-const createErrorImage = (type: ErrorType): JSX.Element => {
-  switch (type) {
-    case errorType.notFound:
-      return <NotFoundImage />;
-    case errorType.internalServerError:
-      return <InternalServerErrorImage />;
-    case errorType.serviceUnavailable:
-      return <ServiceUnavailableImage />;
     default:
       return assertNever(type);
   }
@@ -189,13 +138,35 @@ const createErrorMessageText = (
 type Props = {
   type: ErrorType;
   language: Language;
+  catImage: ReactNode;
 };
 
-export const ErrorTemplate: FC<Props> = ({ type, language }) => (
-  <Wrapper>
-    <Title>{createErrorTitleText(type)}</Title>
-    {createErrorImage(type)}
-    <Message>{createErrorMessageText(type, language)}</Message>
-    <BackToTopButton language={language} />
-  </Wrapper>
-);
+export const ErrorTemplate: FC<Props> = ({ type, language, catImage }) => {
+  const {
+    isLanguageMenuDisplayed,
+    selectedLanguage,
+    onClickEn,
+    onClickJa,
+    onClickLanguageButton,
+    onClickOutSideMenu,
+  } = useSwitchLanguage(language);
+
+  return (
+    <div onClick={onClickOutSideMenu} aria-hidden="true">
+      <ResponsiveLayout
+        language={selectedLanguage}
+        onClickJa={onClickJa}
+        onClickEn={onClickEn}
+        isLanguageMenuDisplayed={isLanguageMenuDisplayed}
+        onClickLanguageButton={onClickLanguageButton}
+      >
+        <Wrapper>
+          <Title>{createErrorTitleText(type)}</Title>
+          <ImageWrapper>{catImage}</ImageWrapper>
+          <Message>{createErrorMessageText(type, selectedLanguage)}</Message>
+          <BackToTopButton language={selectedLanguage} />
+        </Wrapper>
+      </ResponsiveLayout>
+    </div>
+  );
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/111

# Done の定義

- ErrorTemplate が実践投入出来る形になっている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-rkdiqyneac.chromatic.com/?path=/story/src-templates-errortemplate-errortemplate-tsx--not-found-view-in-japanese

# 変更点概要

ErrorTemplateにLayoutを含めるようにして、完成形の状態に変更。これで言語切替によってテキストが変化するようになった。

またねこ画像は外から受け取れるように変更した。

本PRでPackageのバージョンを v0.12.0 にアップグレード。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
