### PR TITLE
Footerの下に余白が出来ないようにCSSを調整

### DIFF
--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
@@ -6,13 +6,18 @@ import { Header, Props as HeaderProps } from '../../components/Header';
 import type { FC, ReactNode } from 'react';
 
 const Wrapper = styled.div`
-  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 100%;
+  gap: 16px;
+  min-height: 100vh;
 `;
 
 const ContentsWrapper = styled.div`
-  display: block;
-  margin: 16px auto;
+  display: inline-block;
+  margin: 0 auto;
   text-align: center;
+  vertical-align: middle;
 `;
 
 export type Props = FooterProps & HeaderProps & { children: ReactNode };

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -9,10 +9,10 @@ import { ImageUploader, ImageValidator } from '../../types/lgtmImage';
 import type { FC, ReactNode } from 'react';
 
 const ImageWrapper = styled.div`
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: flex-start;
+  display: grid;
+  grid-template-columns: 302px 302px 302px;
   @media (max-width: 767px) {
+    grid-template-columns: 302px;
     justify-content: center;
   }
 `;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/64

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/64 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-hhajgteuzu.chromatic.com/?path=/story/src-templates-errortemplate-errortemplate-tsx--not-found-view-in-japanese

# 変更点概要

Footerの下に余計な余白が出来てしまっていたので、CSSを調整した。

話題になっていた以下の記事を参考にした。

https://zenn.dev/catnose99/articles/a873bbbe25b15b

# レビュアーに重点的にチェックして欲しい点

Footerは下に固定したほうが良いかな？そのあたりの意見をもらえると:pray:

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
