### PR TITLE
Package外部で利用する関数や型定義をexportするように変更

### DIFF
--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,0 +1,9 @@
+export {
+  createSuccessResult,
+  createFailureResult,
+  isSuccessResult,
+  isFailureResult,
+  type Result,
+  SuccessResult,
+  FailureResult,
+} from './result';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './hooks';
 export * from './templates';
 export * from './types';
+export * from './features';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './hooks';
 export * from './templates';
+export * from './types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,9 @@
+export { Language } from './language';
+export {
+  LgtmImageUrl,
+  LgtmImage,
+  AcceptedTypesImageExtension,
+  ImageValidator,
+  ImageUploader,
+  CatImagesFetcher,
+} from './lgtmImage';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/118

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/118 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-vqapboqaco.chromatic.com/?path=/story/src-templates-termsorprivacytemplate-termsorprivacytemplate-tsx--view-privacy-policy-in-japanese

# 変更点概要

`types` 、`features` に定義されている機能はPackageの外でも利用するので、exportする事にした。

本PackageはUIPackageなので `Result` をexportするか迷ったが `UploadTemplate` が要求するPropsが `Result` に依存した形なのでexportするという意思決定をした。

# レビュアーに重点的にチェックして欲しい点

`Result` 型をexportする方針に関して意見をもらえると:pray:

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。