### PR TITLE
言語切替Button押下時にコールバック関数を渡せるように改修

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,4 @@
-export { useSwitchLanguage } from './useSwitchLanguage';
+export {
+  useSwitchLanguage,
+  type ChangeLanguageCallbackFunctions,
+} from './useSwitchLanguage';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,1 @@
-export {
-  useSwitchLanguage,
-  type ChangeLanguageCallbackFunctions,
-} from './useSwitchLanguage';
+export { useSwitchLanguage } from './useSwitchLanguage';

--- a/src/hooks/useSwitchLanguage.ts
+++ b/src/hooks/useSwitchLanguage.ts
@@ -6,12 +6,8 @@ import {
   updateIsLanguageMenuDisplayed,
   updateLanguage,
 } from '../stores/valtio/common';
-import { Language } from '../types';
 
-export type ChangeLanguageCallbackFunctions = {
-  onClickEnCallback: () => void;
-  onClickJaCallback: () => void;
-};
+import type { ChangeLanguageCallbackFunctions, Language } from '../types';
 
 export const useSwitchLanguage = (
   language: Language,

--- a/src/hooks/useSwitchLanguage.ts
+++ b/src/hooks/useSwitchLanguage.ts
@@ -6,9 +6,17 @@ import {
   updateIsLanguageMenuDisplayed,
   updateLanguage,
 } from '../stores/valtio/common';
-import { Language } from '../types/language';
+import { Language } from '../types';
 
-export const useSwitchLanguage = (language: Language) => {
+export type ChangeLanguageCallbackFunctions = {
+  onClickEnCallback: () => void;
+  onClickJaCallback: () => void;
+};
+
+export const useSwitchLanguage = (
+  language: Language,
+  changeLanguageCallbackFunctions?: ChangeLanguageCallbackFunctions,
+) => {
   const snap = useSnapshot(commonStateSelector());
 
   const { isLanguageMenuDisplayed } = snap;
@@ -18,11 +26,19 @@ export const useSwitchLanguage = (language: Language) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onClickEn = (event: MouseEvent<HTMLDivElement>) => {
     updateLanguage('en');
+
+    if (changeLanguageCallbackFunctions) {
+      changeLanguageCallbackFunctions.onClickEnCallback();
+    }
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onClickJa = (event: MouseEvent<HTMLDivElement>) => {
     updateLanguage('ja');
+
+    if (changeLanguageCallbackFunctions) {
+      changeLanguageCallbackFunctions.onClickJaCallback();
+    }
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
@@ -45,11 +45,25 @@ const ServiceUnavailableImage = () => (
   />
 );
 
+const onClickEnCallback = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickEnCallback executed!');
+
+const onClickJaCallback = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickJaCallback executed!');
+
+const changeLanguageCallbackFunctions = {
+  onClickEnCallback,
+  onClickJaCallback,
+};
+
 export const NotFoundViewInJapanese: Story = {
   args: {
     type: 404,
     language: 'ja',
     catImage: <NotFoundImage />,
+    changeLanguageCallbackFunctions,
   },
 };
 
@@ -58,6 +72,7 @@ export const NotFoundViewInEnglish: Story = {
     type: 404,
     language: 'en',
     catImage: <NotFoundImage />,
+    changeLanguageCallbackFunctions,
   },
 };
 
@@ -66,6 +81,7 @@ export const InternalServerErrorViewInJapanese: Story = {
     type: 500,
     language: 'ja',
     catImage: <InternalServerErrorImage />,
+    changeLanguageCallbackFunctions,
   },
 };
 
@@ -74,6 +90,7 @@ export const InternalServerErrorViewInEnglish: Story = {
     type: 500,
     language: 'en',
     catImage: <InternalServerErrorImage />,
+    changeLanguageCallbackFunctions,
   },
 };
 
@@ -82,6 +99,7 @@ export const ServiceUnavailableViewInJapanese: Story = {
     type: 503,
     language: 'ja',
     catImage: <ServiceUnavailableImage />,
+    changeLanguageCallbackFunctions,
   },
 };
 
@@ -90,5 +108,6 @@ export const ServiceUnavailableViewInEnglish: Story = {
     type: 503,
     language: 'en',
     catImage: <ServiceUnavailableImage />,
+    changeLanguageCallbackFunctions,
   },
 };

--- a/src/templates/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.tsx
@@ -2,7 +2,10 @@ import styled from 'styled-components';
 
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
-import { Language } from '../../types/language';
+import {
+  ChangeLanguageCallbackFunctions,
+  Language,
+} from '../../types/language';
 import assertNever from '../../utils/assertNever';
 
 import { BackToTopButton } from './BackToTopButton';
@@ -139,9 +142,15 @@ type Props = {
   type: ErrorType;
   language: Language;
   catImage: ReactNode;
+  changeLanguageCallbackFunctions?: ChangeLanguageCallbackFunctions;
 };
 
-export const ErrorTemplate: FC<Props> = ({ type, language, catImage }) => {
+export const ErrorTemplate: FC<Props> = ({
+  type,
+  language,
+  catImage,
+  changeLanguageCallbackFunctions,
+}) => {
   const {
     isLanguageMenuDisplayed,
     selectedLanguage,
@@ -149,7 +158,7 @@ export const ErrorTemplate: FC<Props> = ({ type, language, catImage }) => {
     onClickJa,
     onClickLanguageButton,
     onClickOutSideMenu,
-  } = useSwitchLanguage(language);
+  } = useSwitchLanguage(language, changeLanguageCallbackFunctions);
 
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
@@ -5,7 +5,7 @@ import assertNever from '../../utils/assertNever';
 
 import { TermsOrPrivacyTemplate, type TemplateType } from '.';
 
-import type { Language } from '../../types/language';
+import type { Language } from '../../types';
 import type { ComponentStoryObj, Meta } from '@storybook/react';
 import type { FC } from 'react';
 

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -5,7 +5,7 @@ import { MarkdownPageTitle } from '../../components/MarkdownPageTitle';
 import { createLinksFromLanguages as createPrivacyPolicyLinksFromLanguages } from '../../features/privacyPolicy';
 import { createLinksFromLanguages as createTermsOfUseLinksFromLanguages } from '../../features/termsOfUse';
 import { ResponsiveLayout } from '../../layouts';
-import { Language } from '../../types/language';
+import { Language } from '../../types';
 import assertNever from '../../utils/assertNever';
 
 import type { FC, MouseEventHandler, ReactNode } from 'react';

--- a/src/templates/TopTemplate/TopTemplate.stories.tsx
+++ b/src/templates/TopTemplate/TopTemplate.stories.tsx
@@ -179,6 +179,19 @@ const fetchNewArrivalCatImagesCallback = () =>
   // eslint-disable-next-line no-console
   console.log('fetchNewArrivalCatImagesCallback executed!');
 
+const onClickEnCallback = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickEnCallback executed!');
+
+const onClickJaCallback = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickJaCallback executed!');
+
+const changeLanguageCallbackFunctions = {
+  onClickEnCallback,
+  onClickJaCallback,
+};
+
 export const ViewInJapanese: Story = {
   args: {
     language: 'ja',
@@ -189,6 +202,7 @@ export const ViewInJapanese: Story = {
     clipboardMarkdownCallback,
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
+    changeLanguageCallbackFunctions,
   },
 };
 
@@ -202,5 +216,6 @@ export const ViewInEnglish: Story = {
     clipboardMarkdownCallback,
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
+    changeLanguageCallbackFunctions,
   },
 };

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -12,7 +12,10 @@ import {
 
 import { AppDescriptionArea } from './AppDescriptionArea';
 
-import type { Language } from '../../types/language';
+import type {
+  Language,
+  ChangeLanguageCallbackFunctions,
+} from '../../types/language';
 import type { CatImagesFetcher, LgtmImage } from '../../types/lgtmImage';
 import type { FC } from 'react';
 
@@ -25,6 +28,7 @@ type Props = {
   clipboardMarkdownCallback?: () => void;
   fetchRandomCatImagesCallback?: () => void;
   fetchNewArrivalCatImagesCallback?: () => void;
+  changeLanguageCallbackFunctions?: ChangeLanguageCallbackFunctions;
 };
 
 // eslint-disable-next-line max-lines-per-function
@@ -37,6 +41,7 @@ export const TopTemplate: FC<Props> = ({
   clipboardMarkdownCallback,
   fetchRandomCatImagesCallback,
   fetchNewArrivalCatImagesCallback,
+  changeLanguageCallbackFunctions,
 }) => {
   const {
     isLanguageMenuDisplayed,
@@ -45,7 +50,7 @@ export const TopTemplate: FC<Props> = ({
     onClickJa,
     onClickLanguageButton,
     onClickOutSideMenu,
-  } = useSwitchLanguage(language);
+  } = useSwitchLanguage(language, changeLanguageCallbackFunctions);
 
   const snap = useSnapshot(lgtmImageStateSelector());
 

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -15,8 +15,9 @@ import { AppDescriptionArea } from './AppDescriptionArea';
 import type {
   Language,
   ChangeLanguageCallbackFunctions,
-} from '../../types/language';
-import type { CatImagesFetcher, LgtmImage } from '../../types/lgtmImage';
+  CatImagesFetcher,
+  LgtmImage,
+} from '../../types';
 import type { FC } from 'react';
 
 type Props = {

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import Image from 'next/image';
 
-import { createSuccessResult } from '../../features/result';
-import { AcceptedTypesImageExtension } from '../../types/lgtmImage';
+import { createSuccessResult } from '../../features';
+import { AcceptedTypesImageExtension } from '../../types';
 import { sleep } from '../../utils/sleep';
 
 import cat from './images/cat.webp';
@@ -40,6 +40,19 @@ const imageUploader = async (
   });
 };
 
+const onClickEnCallback = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickEnCallback executed!');
+
+const onClickJaCallback = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickJaCallback executed!');
+
+const changeLanguageCallbackFunctions = {
+  onClickEnCallback,
+  onClickJaCallback,
+};
+
 export default {
   title: 'src/templates/UploadTemplate/UploadTemplate.tsx',
   component: UploadTemplate,
@@ -53,6 +66,7 @@ export const ViewInJapanese: Story = {
     imageValidator,
     imageUploader,
     catImage: <CatImage />,
+    changeLanguageCallbackFunctions,
   },
 };
 
@@ -62,5 +76,6 @@ export const ViewInEnglish: Story = {
     imageValidator,
     imageUploader,
     catImage: <CatImage />,
+    changeLanguageCallbackFunctions,
   },
 };

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -6,8 +6,9 @@ import { ResponsiveLayout } from '../../layouts';
 import {
   ChangeLanguageCallbackFunctions,
   Language,
-} from '../../types/language';
-import { ImageUploader, ImageValidator } from '../../types/lgtmImage';
+  ImageUploader,
+  ImageValidator,
+} from '../../types';
 
 import type { FC, ReactNode } from 'react';
 

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -3,7 +3,10 @@ import styled from 'styled-components';
 import { UploadForm } from '../../components';
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
-import { Language } from '../../types/language';
+import {
+  ChangeLanguageCallbackFunctions,
+  Language,
+} from '../../types/language';
 import { ImageUploader, ImageValidator } from '../../types/lgtmImage';
 
 import type { FC, ReactNode } from 'react';
@@ -22,6 +25,7 @@ type Props = {
   imageValidator: ImageValidator;
   imageUploader: ImageUploader;
   catImage: ReactNode;
+  changeLanguageCallbackFunctions?: ChangeLanguageCallbackFunctions;
 };
 
 export const UploadTemplate: FC<Props> = ({
@@ -29,6 +33,7 @@ export const UploadTemplate: FC<Props> = ({
   imageValidator,
   imageUploader,
   catImage,
+  changeLanguageCallbackFunctions,
 }) => {
   const {
     isLanguageMenuDisplayed,
@@ -37,7 +42,7 @@ export const UploadTemplate: FC<Props> = ({
     onClickJa,
     onClickLanguageButton,
     onClickOutSideMenu,
-  } = useSwitchLanguage(language);
+  } = useSwitchLanguage(language, changeLanguageCallbackFunctions);
 
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
-export { Language } from './language';
-export {
+export type { Language, ChangeLanguageCallbackFunctions } from './language';
+export type {
   LgtmImageUrl,
   LgtmImage,
   AcceptedTypesImageExtension,

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,1 +1,6 @@
 export type Language = 'ja' | 'en';
+
+export type ChangeLanguageCallbackFunctions = {
+  onClickEnCallback: () => void;
+  onClickJaCallback: () => void;
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/124

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/124 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-dbjubpjhdw.chromatic.com/

# 変更点概要

言語切替時に選択している言語をCookieに記録しておきたいので、言語切替時のコールバック関数を受け取れるように改修した。

またimport方式の簡略化が可能だったので、それらのリファクタリングも実施。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
