### PR TITLE
言語変更時のコールバック関数は言語を引数で受け取るように改修

### DIFF
--- a/src/hooks/useSwitchLanguage.ts
+++ b/src/hooks/useSwitchLanguage.ts
@@ -7,11 +7,11 @@ import {
   updateLanguage,
 } from '../stores/valtio/common';
 
-import type { ChangeLanguageCallbackFunctions, Language } from '../types';
+import type { ChangeLanguageCallback, Language } from '../types';
 
 export const useSwitchLanguage = (
   language: Language,
-  changeLanguageCallbackFunctions?: ChangeLanguageCallbackFunctions,
+  changeLanguageCallback?: ChangeLanguageCallback,
 ) => {
   const snap = useSnapshot(commonStateSelector());
 
@@ -23,8 +23,8 @@ export const useSwitchLanguage = (
   const onClickEn = (event: MouseEvent<HTMLDivElement>) => {
     updateLanguage('en');
 
-    if (changeLanguageCallbackFunctions) {
-      changeLanguageCallbackFunctions.onClickEnCallback();
+    if (changeLanguageCallback) {
+      changeLanguageCallback(selectedLanguage);
     }
   };
 
@@ -32,8 +32,8 @@ export const useSwitchLanguage = (
   const onClickJa = (event: MouseEvent<HTMLDivElement>) => {
     updateLanguage('ja');
 
-    if (changeLanguageCallbackFunctions) {
-      changeLanguageCallbackFunctions.onClickJaCallback();
+    if (changeLanguageCallback) {
+      changeLanguageCallback(selectedLanguage);
     }
   };
 

--- a/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
@@ -45,25 +45,16 @@ const ServiceUnavailableImage = () => (
   />
 );
 
-const onClickEnCallback = () =>
+const changeLanguageCallback = () =>
   // eslint-disable-next-line no-console
-  console.log('onClickEnCallback executed!');
-
-const onClickJaCallback = () =>
-  // eslint-disable-next-line no-console
-  console.log('onClickJaCallback executed!');
-
-const changeLanguageCallbackFunctions = {
-  onClickEnCallback,
-  onClickJaCallback,
-};
+  console.log('changeLanguageCallback executed!');
 
 export const NotFoundViewInJapanese: Story = {
   args: {
     type: 404,
     language: 'ja',
     catImage: <NotFoundImage />,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };
 
@@ -72,7 +63,7 @@ export const NotFoundViewInEnglish: Story = {
     type: 404,
     language: 'en',
     catImage: <NotFoundImage />,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };
 
@@ -81,7 +72,7 @@ export const InternalServerErrorViewInJapanese: Story = {
     type: 500,
     language: 'ja',
     catImage: <InternalServerErrorImage />,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };
 
@@ -90,7 +81,7 @@ export const InternalServerErrorViewInEnglish: Story = {
     type: 500,
     language: 'en',
     catImage: <InternalServerErrorImage />,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };
 
@@ -99,7 +90,7 @@ export const ServiceUnavailableViewInJapanese: Story = {
     type: 503,
     language: 'ja',
     catImage: <ServiceUnavailableImage />,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };
 
@@ -108,6 +99,6 @@ export const ServiceUnavailableViewInEnglish: Story = {
     type: 503,
     language: 'en',
     catImage: <ServiceUnavailableImage />,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };

--- a/src/templates/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.tsx
@@ -2,10 +2,7 @@ import styled from 'styled-components';
 
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
-import {
-  ChangeLanguageCallbackFunctions,
-  Language,
-} from '../../types/language';
+import { ChangeLanguageCallback, Language } from '../../types/language';
 import assertNever from '../../utils/assertNever';
 
 import { BackToTopButton } from './BackToTopButton';
@@ -142,14 +139,14 @@ type Props = {
   type: ErrorType;
   language: Language;
   catImage: ReactNode;
-  changeLanguageCallbackFunctions?: ChangeLanguageCallbackFunctions;
+  changeLanguageCallback?: ChangeLanguageCallback;
 };
 
 export const ErrorTemplate: FC<Props> = ({
   type,
   language,
   catImage,
-  changeLanguageCallbackFunctions,
+  changeLanguageCallback,
 }) => {
   const {
     isLanguageMenuDisplayed,
@@ -158,7 +155,7 @@ export const ErrorTemplate: FC<Props> = ({
     onClickJa,
     onClickLanguageButton,
     onClickOutSideMenu,
-  } = useSwitchLanguage(language, changeLanguageCallbackFunctions);
+  } = useSwitchLanguage(language, changeLanguageCallback);
 
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
@@ -230,6 +230,10 @@ type Props = {
 };
 
 const EnhanceTermsOrPrivacyTemplate: FC<Props> = ({ type, language }) => {
+  const changeLanguageCallback = () =>
+    // eslint-disable-next-line no-console
+    console.log('changeLanguageCallback executed!');
+
   const {
     isLanguageMenuDisplayed,
     selectedLanguage,
@@ -237,7 +241,7 @@ const EnhanceTermsOrPrivacyTemplate: FC<Props> = ({ type, language }) => {
     onClickJa,
     onClickLanguageButton,
     onClickOutSideMenu,
-  } = useSwitchLanguage(language);
+  } = useSwitchLanguage(language, changeLanguageCallback);
 
   return (
     <TermsOrPrivacyTemplate

--- a/src/templates/TopTemplate/TopTemplate.stories.tsx
+++ b/src/templates/TopTemplate/TopTemplate.stories.tsx
@@ -179,18 +179,9 @@ const fetchNewArrivalCatImagesCallback = () =>
   // eslint-disable-next-line no-console
   console.log('fetchNewArrivalCatImagesCallback executed!');
 
-const onClickEnCallback = () =>
+const changeLanguageCallback = () =>
   // eslint-disable-next-line no-console
-  console.log('onClickEnCallback executed!');
-
-const onClickJaCallback = () =>
-  // eslint-disable-next-line no-console
-  console.log('onClickJaCallback executed!');
-
-const changeLanguageCallbackFunctions = {
-  onClickEnCallback,
-  onClickJaCallback,
-};
+  console.log('changeLanguageCallback executed!');
 
 export const ViewInJapanese: Story = {
   args: {
@@ -202,7 +193,7 @@ export const ViewInJapanese: Story = {
     clipboardMarkdownCallback,
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };
 
@@ -216,6 +207,6 @@ export const ViewInEnglish: Story = {
     clipboardMarkdownCallback,
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -14,7 +14,7 @@ import { AppDescriptionArea } from './AppDescriptionArea';
 
 import type {
   Language,
-  ChangeLanguageCallbackFunctions,
+  ChangeLanguageCallback,
   CatImagesFetcher,
   LgtmImage,
 } from '../../types';
@@ -29,7 +29,7 @@ type Props = {
   clipboardMarkdownCallback?: () => void;
   fetchRandomCatImagesCallback?: () => void;
   fetchNewArrivalCatImagesCallback?: () => void;
-  changeLanguageCallbackFunctions?: ChangeLanguageCallbackFunctions;
+  changeLanguageCallback?: ChangeLanguageCallback;
 };
 
 // eslint-disable-next-line max-lines-per-function
@@ -42,7 +42,7 @@ export const TopTemplate: FC<Props> = ({
   clipboardMarkdownCallback,
   fetchRandomCatImagesCallback,
   fetchNewArrivalCatImagesCallback,
-  changeLanguageCallbackFunctions,
+  changeLanguageCallback,
 }) => {
   const {
     isLanguageMenuDisplayed,
@@ -51,7 +51,7 @@ export const TopTemplate: FC<Props> = ({
     onClickJa,
     onClickLanguageButton,
     onClickOutSideMenu,
-  } = useSwitchLanguage(language, changeLanguageCallbackFunctions);
+  } = useSwitchLanguage(language, changeLanguageCallback);
 
   const snap = useSnapshot(lgtmImageStateSelector());
 

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -40,18 +40,9 @@ const imageUploader = async (
   });
 };
 
-const onClickEnCallback = () =>
+const changeLanguageCallback = () =>
   // eslint-disable-next-line no-console
-  console.log('onClickEnCallback executed!');
-
-const onClickJaCallback = () =>
-  // eslint-disable-next-line no-console
-  console.log('onClickJaCallback executed!');
-
-const changeLanguageCallbackFunctions = {
-  onClickEnCallback,
-  onClickJaCallback,
-};
+  console.log('changeLanguageCallback executed!');
 
 export default {
   title: 'src/templates/UploadTemplate/UploadTemplate.tsx',
@@ -66,7 +57,7 @@ export const ViewInJapanese: Story = {
     imageValidator,
     imageUploader,
     catImage: <CatImage />,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };
 
@@ -76,6 +67,6 @@ export const ViewInEnglish: Story = {
     imageValidator,
     imageUploader,
     catImage: <CatImage />,
-    changeLanguageCallbackFunctions,
+    changeLanguageCallback,
   },
 };

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -4,7 +4,7 @@ import { UploadForm } from '../../components';
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
 import {
-  ChangeLanguageCallbackFunctions,
+  ChangeLanguageCallback,
   Language,
   ImageUploader,
   ImageValidator,
@@ -26,7 +26,7 @@ type Props = {
   imageValidator: ImageValidator;
   imageUploader: ImageUploader;
   catImage: ReactNode;
-  changeLanguageCallbackFunctions?: ChangeLanguageCallbackFunctions;
+  changeLanguageCallback?: ChangeLanguageCallback;
 };
 
 export const UploadTemplate: FC<Props> = ({
@@ -34,7 +34,7 @@ export const UploadTemplate: FC<Props> = ({
   imageValidator,
   imageUploader,
   catImage,
-  changeLanguageCallbackFunctions,
+  changeLanguageCallback,
 }) => {
   const {
     isLanguageMenuDisplayed,
@@ -43,7 +43,7 @@ export const UploadTemplate: FC<Props> = ({
     onClickJa,
     onClickLanguageButton,
     onClickOutSideMenu,
-  } = useSwitchLanguage(language, changeLanguageCallbackFunctions);
+  } = useSwitchLanguage(language, changeLanguageCallback);
 
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { Language, ChangeLanguageCallbackFunctions } from './language';
+export type { Language, ChangeLanguageCallback } from './language';
 export type {
   LgtmImageUrl,
   LgtmImage,

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,6 +1,3 @@
 export type Language = 'ja' | 'en';
 
-export type ChangeLanguageCallbackFunctions = {
-  onClickEnCallback: () => void;
-  onClickJaCallback: () => void;
-};
+export type ChangeLanguageCallback = (language: Language) => void;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/127

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/127 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-kwlhpxdcmm.chromatic.com/?path=/story/src-templates-uploadtemplate-uploadtemplate-tsx--view-in-english

# 変更点概要

表題の通り、言語変更時のコールバック関数は言語を引数で受け取るように改修。

こうしないと変更された言語情報をCookieに保存出来なかったので改修を行った。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
