### PR TITLE
changeLanguageCallbackに渡す引数は変更された後の言語を渡すように変更

### DIFF
--- a/src/hooks/useSwitchLanguage.ts
+++ b/src/hooks/useSwitchLanguage.ts
@@ -9,6 +9,10 @@ import {
 
 import type { ChangeLanguageCallback, Language } from '../types';
 
+const languageEn = 'en';
+
+const languageJa = 'ja';
+
 export const useSwitchLanguage = (
   language: Language,
   changeLanguageCallback?: ChangeLanguageCallback,
@@ -21,19 +25,19 @@ export const useSwitchLanguage = (
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onClickEn = (event: MouseEvent<HTMLDivElement>) => {
-    updateLanguage('en');
+    updateLanguage(languageEn);
 
     if (changeLanguageCallback) {
-      changeLanguageCallback(selectedLanguage);
+      changeLanguageCallback(languageEn);
     }
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onClickJa = (event: MouseEvent<HTMLDivElement>) => {
-    updateLanguage('ja');
+    updateLanguage(languageJa);
 
     if (changeLanguageCallback) {
-      changeLanguageCallback(selectedLanguage);
+      changeLanguageCallback(languageJa);
     }
   };
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/127

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/127 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-cewdkmirfz.chromatic.com/

# 変更点概要

`changeLanguageCallback` には `selectedLanguage` を渡していたがこれだと意図した動作にならないので、決め打ちで変更された後の言語を渡すように変更。

英語に変更された際は `en` 、日本語に変更された際は `ja` を固定で渡すようになっている。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。