### PR TITLE
ErrorTemplate.ErrorType をexportするように変更

### DIFF
--- a/src/templates/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.tsx
@@ -49,7 +49,7 @@ const errorType = {
   serviceUnavailable: 503,
 } as const;
 
-type ErrorType = typeof errorType[keyof typeof errorType];
+export type ErrorType = typeof errorType[keyof typeof errorType];
 
 const errorTitleText = {
   notFound: '404 Not Found',

--- a/src/templates/ErrorTemplate/index.ts
+++ b/src/templates/ErrorTemplate/index.ts
@@ -1,1 +1,1 @@
-export { ErrorTemplate } from './ErrorTemplate';
+export { ErrorTemplate, ErrorType } from './ErrorTemplate';

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,4 +1,4 @@
-export { ErrorTemplate } from './ErrorTemplate';
-export { UploadTemplate } from './UploadTemplate';
-export { TermsOrPrivacyTemplate } from './TermsOrPrivacyTemplate';
-export { TopTemplate } from './TopTemplate';
+export * from './ErrorTemplate';
+export * from './UploadTemplate';
+export * from './TermsOrPrivacyTemplate';
+export * from './TopTemplate';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/123

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/123 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-czaswoeghs.chromatic.com/?path=/story/src-templates-errortemplate-errortemplate-tsx--not-found-view-in-japanese

# 変更点概要

`ErrorTemplate` で設定出来る値は決まっているので型定義をexportするように変更。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
