### PR TITLE
アップロード完了後に呼び出すコールバック関数を受け取れるように改修

### DIFF
--- a/src/components/Upload/UploadForm/UploadForm.stories.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.stories.tsx
@@ -67,11 +67,25 @@ const imageUploaderWithErrors = async (
   });
 };
 
+// eslint-disable-next-line no-console
+const uploadCallback = () => console.log('uploadCallback executed!');
+
+const onClickCreatedLgtmImage = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickCreatedLgtmImage executed!');
+
+const onClickMarkdownSourceCopyButton = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickMarkdownSourceCopyButton executed!');
+
 export const ViewInJapanese: Story = {
   args: {
     language: 'ja',
     imageValidator,
     imageUploader,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
   },
 };
 
@@ -80,6 +94,9 @@ export const ViewInJapaneseWithReturnFalseImageValidator: Story = {
     language: 'ja',
     imageValidator: returnFalseImageValidator,
     imageUploader,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
   },
 };
 
@@ -88,6 +105,9 @@ export const ViewInJapaneseWithImageUploaderWithErrors: Story = {
     language: 'ja',
     imageValidator,
     imageUploader: imageUploaderWithErrors,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
   },
 };
 
@@ -96,6 +116,9 @@ export const ViewInEnglish: Story = {
     language: 'en',
     imageValidator,
     imageUploader,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
   },
 };
 
@@ -104,6 +127,9 @@ export const ViewInEnglishWithReturnFalseImageValidator: Story = {
     language: 'en',
     imageValidator: returnFalseImageValidator,
     imageUploader,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
   },
 };
 
@@ -112,5 +138,8 @@ export const ViewInEnglishWithImageUploaderWithErrors: Story = {
     language: 'en',
     imageValidator,
     imageUploader: imageUploaderWithErrors,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
   },
 };

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -90,6 +90,9 @@ export type Props = {
   language: Language;
   imageValidator: ImageValidator;
   imageUploader: ImageUploader;
+  uploadCallback?: () => void;
+  onClickCreatedLgtmImage?: () => void;
+  onClickMarkdownSourceCopyButton?: () => void;
 };
 
 // eslint-disable-next-line max-lines-per-function, max-statements
@@ -97,6 +100,9 @@ export const UploadForm: FC<Props> = ({
   language,
   imageValidator,
   imageUploader,
+  uploadCallback,
+  onClickCreatedLgtmImage,
+  onClickMarkdownSourceCopyButton,
 }) => {
   const [base64Image, setBase64Image] = useState<string>('');
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string>('');
@@ -223,6 +229,10 @@ export const UploadForm: FC<Props> = ({
       setUploaded(true);
       setDisplayErrorMessages([]);
       setCreatedLgtmImageUrl(imageUploadResult.value.createdLgtmImageUrl);
+
+      if (uploadCallback) {
+        uploadCallback();
+      }
     }
 
     // eslint-disable-next-line no-magic-numbers
@@ -301,6 +311,8 @@ export const UploadForm: FC<Props> = ({
           isLoading={isLoading}
           uploaded={uploaded}
           createdLgtmImageUrl={createdLgtmImageUrl}
+          onClickCreatedLgtmImage={onClickCreatedLgtmImage}
+          onClickMarkdownSourceCopyButton={onClickMarkdownSourceCopyButton}
         />
       ) : (
         ''

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -20,8 +20,10 @@ export type Props = {
   onClickCancel: () => void;
   onClickClose: () => void;
   isLoading: boolean;
-  uploaded?: boolean;
   createdLgtmImageUrl: LgtmImageUrl | string;
+  uploaded?: boolean;
+  onClickCreatedLgtmImage?: () => void;
+  onClickMarkdownSourceCopyButton?: () => void;
 };
 
 const Wrapper = styled.div`
@@ -153,6 +155,8 @@ export const UploadModal: FC<Props> = ({
   isLoading,
   uploaded = false,
   createdLgtmImageUrl,
+  onClickCreatedLgtmImage,
+  onClickMarkdownSourceCopyButton,
 }) => {
   if (uploaded) {
     modalStyle.content.height = '705px';
@@ -175,6 +179,7 @@ export const UploadModal: FC<Props> = ({
               <CreatedLgtmImage
                 imagePreviewUrl={imagePreviewUrl}
                 createdLgtmImageUrl={createdLgtmImageUrl}
+                callback={onClickCreatedLgtmImage}
               />
             ) : (
               <PreviewImageWrapper>
@@ -194,6 +199,7 @@ export const UploadModal: FC<Props> = ({
               language={language}
               createdLgtmImageUrl={createdLgtmImageUrl}
               onClickClose={onClickClose}
+              callback={onClickMarkdownSourceCopyButton}
             />
           ) : (
             ''

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -44,6 +44,17 @@ const changeLanguageCallback = () =>
   // eslint-disable-next-line no-console
   console.log('changeLanguageCallback executed!');
 
+// eslint-disable-next-line no-console
+const uploadCallback = () => console.log('uploadCallback executed!');
+
+const onClickCreatedLgtmImage = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickCreatedLgtmImage executed!');
+
+const onClickMarkdownSourceCopyButton = () =>
+  // eslint-disable-next-line no-console
+  console.log('onClickMarkdownSourceCopyButton executed!');
+
 export default {
   title: 'src/templates/UploadTemplate/UploadTemplate.tsx',
   component: UploadTemplate,
@@ -58,6 +69,9 @@ export const ViewInJapanese: Story = {
     imageUploader,
     catImage: <CatImage />,
     changeLanguageCallback,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
   },
 };
 
@@ -68,5 +82,8 @@ export const ViewInEnglish: Story = {
     imageUploader,
     catImage: <CatImage />,
     changeLanguageCallback,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
   },
 };

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -27,6 +27,9 @@ type Props = {
   imageUploader: ImageUploader;
   catImage: ReactNode;
   changeLanguageCallback?: ChangeLanguageCallback;
+  uploadCallback?: () => void;
+  onClickCreatedLgtmImage?: () => void;
+  onClickMarkdownSourceCopyButton?: () => void;
 };
 
 export const UploadTemplate: FC<Props> = ({
@@ -35,6 +38,9 @@ export const UploadTemplate: FC<Props> = ({
   imageUploader,
   catImage,
   changeLanguageCallback,
+  uploadCallback,
+  onClickCreatedLgtmImage,
+  onClickMarkdownSourceCopyButton,
 }) => {
   const {
     isLanguageMenuDisplayed,
@@ -58,6 +64,9 @@ export const UploadTemplate: FC<Props> = ({
           language={selectedLanguage}
           imageValidator={imageValidator}
           imageUploader={imageUploader}
+          uploadCallback={uploadCallback}
+          onClickCreatedLgtmImage={onClickCreatedLgtmImage}
+          onClickMarkdownSourceCopyButton={onClickMarkdownSourceCopyButton}
         />
         <ImageWrapper>{catImage}</ImageWrapper>
       </ResponsiveLayout>


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/116

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/116 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-jssrhggvbw.chromatic.com/?path=/story/src-templates-uploadtemplate-uploadtemplate-tsx--view-in-english

# 変更点概要

アップロード完了時に実行するコールバック関数（`uploadCallback`）を渡せるように改修。

これはGAなどでイベント送信を行う事を想定した改修。

Modalの画像やCopyButtonをClickするとMarkdownSourceがコピーされるが、これらが実行された際もGAイベントを送信する可能性があるので、`onClickCreatedLgtmImage`, `onClickMarkdownSourceCopyButton` も追加した。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。