### PR TITLE
Propsで受け取った非同期の関数で例外が発生した場合のエラーハンドリングを追加

### DIFF
--- a/src/components/Upload/UploadForm/UploadForm.stories.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.stories.tsx
@@ -35,8 +35,7 @@ const returnFalseImageValidator = async (
   return createSuccessResult({
     isAcceptableCatImage: false,
     notAcceptableReason: [
-      'An unexpected error occurred during upload.',
-      'Sorry, please try again after some time has passed.',
+      "Sorry, please use images that do not show people's faces.",
     ],
   });
 };

--- a/src/components/Upload/UploadForm/UploadForm.stories.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.stories.tsx
@@ -41,6 +41,15 @@ const returnFalseImageValidator = async (
   });
 };
 
+const throwErrorImageValidator = async (
+  image: string,
+  imageExtension: AcceptedTypesImageExtension,
+) => {
+  await sleep();
+
+  throw new Error('throwErrorImageValidator');
+};
+
 const imageUploader = async (
   image: string,
   imageExtension: AcceptedTypesImageExtension,
@@ -65,6 +74,15 @@ const imageUploaderWithErrors = async (
       'Sorry, but please use images that clearly show the cat.',
     ],
   });
+};
+
+const throwErrorImageUploader = async (
+  image: string,
+  imageExtension: AcceptedTypesImageExtension,
+) => {
+  await sleep();
+
+  throw new Error('throwErrorImageUploader');
 };
 
 // eslint-disable-next-line no-console
@@ -111,6 +129,28 @@ export const ViewInJapaneseWithImageUploaderWithErrors: Story = {
   },
 };
 
+export const ViewInJapaneseWithThrowErrorImageValidator: Story = {
+  args: {
+    language: 'ja',
+    imageValidator: throwErrorImageValidator,
+    imageUploader,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
+  },
+};
+
+export const ViewInJapaneseWithThrowErrorImageUploader: Story = {
+  args: {
+    language: 'ja',
+    imageValidator,
+    imageUploader: throwErrorImageUploader,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
+  },
+};
+
 export const ViewInEnglish: Story = {
   args: {
     language: 'en',
@@ -138,6 +178,28 @@ export const ViewInEnglishWithImageUploaderWithErrors: Story = {
     language: 'en',
     imageValidator,
     imageUploader: imageUploaderWithErrors,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
+  },
+};
+
+export const ViewInEnglishWithThrowErrorImageValidator: Story = {
+  args: {
+    language: 'en',
+    imageValidator: throwErrorImageValidator,
+    imageUploader,
+    uploadCallback,
+    onClickCreatedLgtmImage,
+    onClickMarkdownSourceCopyButton,
+  },
+};
+
+export const ViewInEnglishWithThrowErrorImageUploader: Story = {
+  args: {
+    language: 'en',
+    imageValidator,
+    imageUploader: throwErrorImageUploader,
     uploadCallback,
     onClickCreatedLgtmImage,
     onClickMarkdownSourceCopyButton,

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -39,6 +39,7 @@ import {
   createNotAllowedImageExtensionErrorMessage,
   imageDropAreaText,
   noteList,
+  unexpectedErrorMessage,
   uploadInputButtonText,
 } from './i18n';
 
@@ -204,41 +205,51 @@ export const UploadForm: FC<Props> = ({
   const executeUpload = async () => {
     setIsLoading(true);
 
-    const imageValidationResult = await imageValidator(
-      base64Image,
-      uploadImageExtension as AcceptedTypesImageExtension,
-    );
-    if (
-      !imageValidationResult.value.isAcceptableCatImage ||
-      // eslint-disable-next-line no-magic-numbers
-      imageValidationResult.value.notAcceptableReason.length !== 0
-    ) {
-      setDisplayErrorMessages(imageValidationResult.value.notAcceptableReason);
-      stateInitAtError();
+    try {
+      const imageValidationResult = await imageValidator(
+        base64Image,
+        uploadImageExtension as AcceptedTypesImageExtension,
+      );
 
-      return;
-    }
+      if (
+        !imageValidationResult.value.isAcceptableCatImage ||
+        // eslint-disable-next-line no-magic-numbers
+        imageValidationResult.value.notAcceptableReason.length !== 0
+      ) {
+        setDisplayErrorMessages(
+          imageValidationResult.value.notAcceptableReason,
+        );
+        stateInitAtError();
 
-    const imageUploadResult = await imageUploader(
-      base64Image,
-      uploadImageExtension as AcceptedTypesImageExtension,
-    );
-
-    setIsLoading(false);
-    if (imageUploadResult.value.createdLgtmImageUrl) {
-      setUploaded(true);
-      setDisplayErrorMessages([]);
-      setCreatedLgtmImageUrl(imageUploadResult.value.createdLgtmImageUrl);
-
-      if (uploadCallback) {
-        uploadCallback();
+        return;
       }
-    }
 
-    // eslint-disable-next-line no-magic-numbers
-    if (imageUploadResult.value.displayErrorMessages.length !== 0) {
-      setDisplayErrorMessages(imageUploadResult.value.displayErrorMessages);
+      const imageUploadResult = await imageUploader(
+        base64Image,
+        uploadImageExtension as AcceptedTypesImageExtension,
+      );
+
+      setIsLoading(false);
+      if (imageUploadResult.value.createdLgtmImageUrl) {
+        setUploaded(true);
+        setDisplayErrorMessages([]);
+        setCreatedLgtmImageUrl(imageUploadResult.value.createdLgtmImageUrl);
+
+        if (uploadCallback) {
+          uploadCallback();
+        }
+      }
+
+      // eslint-disable-next-line no-magic-numbers
+      if (imageUploadResult.value.displayErrorMessages.length !== 0) {
+        setDisplayErrorMessages(imageUploadResult.value.displayErrorMessages);
+        stateInitAtError();
+      }
+    } catch (error) {
+      setDisplayErrorMessages(unexpectedErrorMessage(language));
       stateInitAtError();
+    } finally {
+      setIsLoading(false);
     }
   };
 

--- a/src/components/Upload/UploadForm/i18n.ts
+++ b/src/components/Upload/UploadForm/i18n.ts
@@ -74,3 +74,20 @@ export const createNotAllowedImageExtensionErrorMessage = (
       return assertNever(language);
   }
 };
+
+export const unexpectedErrorMessage = (language: Language): string[] => {
+  switch (language) {
+    case 'ja':
+      return [
+        '予期せぬエラーが発生しました。',
+        'お手数ですが、しばらく時間が経ってからお試し下さい。',
+      ];
+    case 'en':
+      return [
+        'An unexpected error occurred during upload.',
+        'Sorry, please try again after some time has passed.',
+      ];
+    default:
+      return assertNever(language);
+  }
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/122

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/122 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-tndaadzkpm.chromatic.com/?path=/story/src-components-upload-uploadform-uploadform-tsx--view-in-japanese-with-throw-error-image-validator

# 変更点概要

ねこ画像アップロード用の関数やねこ画像判定用関数でErrorがThrowされた場合、ローディング中で固まってしまっていたのでエラーハンドリングを追加した。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。

