### PR TITLE
アップロードされた画像の拡張子がStateに保存されていなかったので対応

### DIFF
--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, type FC, FormEvent, ChangeEvent } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { FaCloudUploadAlt } from 'react-icons/fa';
 
-import { isValidFileType } from '../../../features/lgtmImage';
+import { isValidFileType , extractImageExtFromValidFileType } from '../../../features/lgtmImage';
 import { createLinksFromLanguages } from '../../../features/privacyPolicy';
 import {
   AcceptedTypesImageExtension,
@@ -167,6 +167,7 @@ export const UploadForm: FC<Props> = ({
     const url = URL.createObjectURL(file);
 
     setImagePreviewUrl(url);
+    setUploadImageExtension(extractImageExtFromValidFileType(fileType));
 
     const reader = new FileReader();
     reader.onload = handleReaderLoaded;

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -4,14 +4,18 @@ import { useState, useCallback, type FC, FormEvent, ChangeEvent } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { FaCloudUploadAlt } from 'react-icons/fa';
 
-import { isValidFileType , extractImageExtFromValidFileType } from '../../../features/lgtmImage';
+import {
+  isValidFileType,
+  extractImageExtFromValidFileType,
+} from '../../../features/lgtmImage';
 import { createLinksFromLanguages } from '../../../features/privacyPolicy';
 import {
   AcceptedTypesImageExtension,
   ImageUploader,
   ImageValidator,
   LgtmImageUrl,
-} from '../../../types/lgtmImage';
+  Language,
+} from '../../../types';
 import assertNever from '../../../utils/assertNever';
 import { UploadButton } from '../UploadButton';
 import { UploadErrorMessageArea } from '../UploadErrorMessageArea';
@@ -42,8 +46,6 @@ import {
   unexpectedErrorMessage,
   uploadInputButtonText,
 } from './i18n';
-
-import type { Language } from '../../../types/language';
 
 const faCloudUploadAltStyle = {
   fontStyle: 'normal',


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/145

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/145 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-whmfehbgkc.chromatic.com/?path=/story/src-templates-uploadtemplate-uploadtemplate-tsx--view-in-japanese

# 変更点概要

表題のバグを修正。

`extractImageExtFromValidFileType` という関数を以前作成していたが、それをコールするのを忘れていて、その結果 `imageValidator`  に渡す `uploadImageExtension` が常に空文字になってしまっていた。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
