### PR TITLE
グローバルメニュー用Componentの追加

### DIFF
--- a/src/components/GlobalMenu/GlobalMenu.stories.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.stories.tsx
@@ -9,4 +9,10 @@ export default {
 
 type Story = ComponentStoryObj<typeof GlobalMenu>;
 
-export const Default: Story = {};
+export const ViewInJapanese: Story = {
+  args: { language: 'ja' },
+};
+
+export const ViewInEnglish: Story = {
+  args: { language: 'en' },
+};

--- a/src/components/GlobalMenu/GlobalMenu.stories.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.stories.tsx
@@ -1,0 +1,12 @@
+import { GlobalMenu } from './';
+
+import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+export default {
+  title: 'src/components/GlobalMenu/GlobalMenu.tsx',
+  component: GlobalMenu,
+} as Meta<typeof GlobalMenu>;
+
+type Story = ComponentStoryObj<typeof GlobalMenu>;
+
+export const Default: Story = {};

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -96,9 +96,10 @@ const faCloudUploadAltStyle = {
 
 export type Props = {
   language: Language;
+  onClickCloseButton: () => void;
 };
 
-export const GlobalMenu: FC<Props> = ({ language }) => {
+export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
   const termsOfUseLinks = createTermsOfUseLinks(language);
 
   const privacyPolicyLinks = createPrivacyPolicyLinks(language);
@@ -106,7 +107,7 @@ export const GlobalMenu: FC<Props> = ({ language }) => {
   return (
     <Wrapper>
       <HeaderWrapper>
-        <FaTimesWrapper>
+        <FaTimesWrapper onClick={onClickCloseButton}>
           <FaTimes style={faTimesStyle} />
         </FaTimesWrapper>
       </HeaderWrapper>

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -1,1 +1,144 @@
-export const GlobalMenu = () => <div>GlobalMenu</div>;
+import Link from 'next/link';
+import { FaTimes, FaCloudUploadAlt } from 'react-icons/fa';
+import styled from 'styled-components';
+
+import { createLinksFromLanguages as createPrivacyPolicyLinks } from './../../features/privacyPolicy';
+import { createLinksFromLanguages as createTermsOfUseLinks } from './../../features/termsOfUse';
+
+import type { Language } from '../../types';
+import type { FC } from 'react';
+
+const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+  justify-content: center;
+  width: 69px;
+  height: 35px;
+  padding: 10px 22px 7px 0;
+`;
+
+const HeaderWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 10px 22px 7px 0;
+`;
+
+const FaTimesWrapper = styled.div`
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 30px;
+  height: 30px;
+`;
+
+const faTimesStyle = {
+  fontStyle: 'normal',
+  fontWeight: 900,
+  fontSize: '30px',
+  lineHeight: '30px',
+  color: '#eb7c06',
+  cursor: 'pointer',
+};
+
+const LinkGroupWrapper = styled.div`
+  position: absolute;
+  top: 73px;
+  left: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 305px;
+  height: 180px;
+  padding: 0;
+`;
+
+const LinkWrapper = styled.div`
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 305px;
+  height: 45px;
+`;
+
+const LinkText = styled.a`
+  display: flex;
+  align-items: center;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 30px;
+  color: #eb7c06;
+  text-decoration-line: underline;
+  cursor: pointer;
+`;
+
+const UnderLine = styled.div`
+  box-sizing: border-box;
+  background: #faf9f7;
+  border-bottom: 1px solid #f2ebdf;
+`;
+
+const faCloudUploadAltStyle = {
+  fontStyle: 'normal',
+  fontWeight: 900,
+  fontSize: '16px',
+  lineHeight: '30px',
+  color: '#eb7c06',
+  marginRight: '10px',
+};
+
+export type Props = {
+  language: Language;
+};
+
+export const GlobalMenu: FC<Props> = ({ language }) => {
+  const termsOfUseLinks = createTermsOfUseLinks(language);
+
+  const privacyPolicyLinks = createPrivacyPolicyLinks(language);
+
+  return (
+    <Wrapper>
+      <HeaderWrapper>
+        <FaTimesWrapper>
+          <FaTimes style={faTimesStyle} />
+        </FaTimesWrapper>
+      </HeaderWrapper>
+      <LinkGroupWrapper>
+        <LinkWrapper>
+          <Link href="/" prefetch={false}>
+            <LinkText>TOP</LinkText>
+          </Link>
+          <UnderLine />
+        </LinkWrapper>
+        <LinkWrapper>
+          <Link href="/upload" prefetch={false}>
+            <LinkText>
+              <FaCloudUploadAlt style={faCloudUploadAltStyle} />
+              Upload new Cats
+            </LinkText>
+          </Link>
+          <UnderLine />
+        </LinkWrapper>
+        <LinkWrapper>
+          <Link href={termsOfUseLinks.link} prefetch={false}>
+            <LinkText>{termsOfUseLinks.text}</LinkText>
+          </Link>
+          <UnderLine />
+        </LinkWrapper>
+        <LinkWrapper>
+          <Link href={privacyPolicyLinks.link} prefetch={false}>
+            <LinkText>{privacyPolicyLinks.text}</LinkText>
+          </Link>
+          <UnderLine />
+        </LinkWrapper>
+      </LinkGroupWrapper>
+    </Wrapper>
+  );
+};

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -1,0 +1,1 @@
+export const GlobalMenu = () => <div>GlobalMenu</div>;

--- a/src/components/GlobalMenu/index.ts
+++ b/src/components/GlobalMenu/index.ts
@@ -1,0 +1,1 @@
+export { GlobalMenu } from './GlobalMenu';

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,11 +1,13 @@
 import Link from 'next/link';
+import { useState, type FC, MouseEvent } from 'react';
 import { FaBars } from 'react-icons/fa';
+import Modal from 'react-modal';
 import styled from 'styled-components';
+
+import { GlobalMenu } from '../GlobalMenu';
 
 import { LanguageButton } from './LanguageButton';
 import { LanguageMenu, Props as LanguageMenuProps } from './LanguageMenu';
-
-import type { FC, MouseEvent } from 'react';
 
 const Wrapper = styled.div`
   background: #e9e2d7;
@@ -57,31 +59,64 @@ export type Props = LanguageMenuProps & {
   onClickLanguageButton: (event: MouseEvent<HTMLDivElement>) => void;
 };
 
+const modalStyle = {
+  // stylelint-disable-next-line
+  overlay: {
+    background: 'rgba(54, 46, 43, 0.7)',
+  },
+  content: {
+    top: '0',
+    left: '0',
+    width: '365px',
+    height: '100vh',
+  },
+};
+
 export const Header: FC<Props> = ({
   language,
   isLanguageMenuDisplayed,
   onClickLanguageButton,
   onClickEn,
   onClickJa,
-}) => (
-  <>
-    <Wrapper>
-      <StyledHeader>
-        <FaBars style={faBarsStyle} />
-        <Link href="/" prefetch={false}>
-          <Title>LGTMeow</Title>
-        </Link>
-        <LanguageButton onClick={onClickLanguageButton} />
-        {isLanguageMenuDisplayed ? (
-          <LanguageMenu
-            language={language}
-            onClickEn={onClickEn}
-            onClickJa={onClickJa}
-          />
-        ) : (
-          ''
-        )}
-      </StyledHeader>
-    </Wrapper>
-  </>
-);
+}) => {
+  const [isMenuOpened, setIsMenuOpened] = useState<boolean>(false);
+
+  const openMenu = () => {
+    setIsMenuOpened(true);
+  };
+
+  const closeMenu = () => {
+    setIsMenuOpened(false);
+  };
+
+  return (
+    <>
+      <Modal
+        isOpen={isMenuOpened}
+        ariaHideApp={false}
+        style={modalStyle}
+        onRequestClose={closeMenu}
+      >
+        <GlobalMenu language={language} onClickCloseButton={closeMenu} />
+      </Modal>
+      <Wrapper>
+        <StyledHeader>
+          <FaBars style={faBarsStyle} onClick={openMenu} />
+          <Link href="/" prefetch={false}>
+            <Title>LGTMeow</Title>
+          </Link>
+          <LanguageButton onClick={onClickLanguageButton} />
+          {isLanguageMenuDisplayed ? (
+            <LanguageMenu
+              language={language}
+              onClickEn={onClickEn}
+              onClickJa={onClickJa}
+            />
+          ) : (
+            ''
+          )}
+        </StyledHeader>
+      </Wrapper>
+    </>
+  );
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/151

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/151 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

## メニューComponentの本体

https://62729802bbcc7d004a663d4c-qtoajxtbmu.chromatic.com/?path=/story/src-components-globalmenu-globalmenu-tsx--view-in-japanese

## メニューの開閉

https://62729802bbcc7d004a663d4c-qtoajxtbmu.chromatic.com/?path=/story/src-templates-toptemplate-toptemplate-tsx--view-in-japanese

# 変更点概要

Figmaにデザインが上がったので、グローバルメニュー用のComponentを作成。

グローバルナビと呼ぶか、グローバルメニューと呼ぶかは調べた限り特に決まっていないようで、ナビの場合はNaviだったりNavだったりの表記揺れが起こる可能性があるので `GlobalMenu` という名称にした。

# レビュアーに重点的にチェックして欲しい点

`GlobalMenu` Componentの名前に関していい案があれば意見もらえると:pray:

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。