### PR TITLE
paddingの設定がFigmaのデザイン通りになっていない箇所を修正

### DIFF
--- a/.storybook/markdown.css
+++ b/.storybook/markdown.css
@@ -1,0 +1,14 @@
+.markdown h1,
+h2,
+h3 {
+  font-size: 20px;
+  line-height: 2.5;
+}
+
+.markdown p,
+li,
+dt,
+dd {
+  font-size: 15px;
+  line-height: 1.8;
+}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import 'ress/ress.css';
+import './markdown.css';
 
 const customViewports = {
   iPhone12: {

--- a/src/components/MarkdownContents/MarkdownContents.tsx
+++ b/src/components/MarkdownContents/MarkdownContents.tsx
@@ -25,7 +25,7 @@ export type Props = {
 };
 
 export const MarkdownContents: FC<Props> = ({ markdown }) => (
-  <Wrapper>
+  <Wrapper className="markdown">
     <ReactMarkdown>{markdown}</ReactMarkdown>
   </Wrapper>
 );

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
@@ -9,7 +9,7 @@ const Wrapper = styled.div`
   display: grid;
   grid-template-rows: auto 1fr auto;
   grid-template-columns: 100%;
-  gap: 16px;
+  gap: 64px;
   min-height: 100vh;
 `;
 

--- a/src/templates/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.tsx
@@ -12,7 +12,7 @@ import type { FC, ReactNode } from 'react';
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 64px;
   align-items: center;
   justify-content: center;
 `;

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
@@ -1,5 +1,4 @@
-import ReactMarkdown from 'react-markdown';
-
+import { MarkdownContents } from '../../components/MarkdownContents';
 import { useSwitchLanguage } from '../../hooks';
 import assertNever from '../../utils/assertNever';
 
@@ -253,7 +252,7 @@ const EnhanceTermsOrPrivacyTemplate: FC<Props> = ({ type, language }) => {
       onClickLanguageButton={onClickLanguageButton}
       onClickOutSideMenu={onClickOutSideMenu}
     >
-      <ReactMarkdown>{getMarkdownSource(type, selectedLanguage)}</ReactMarkdown>
+      <MarkdownContents markdown={getMarkdownSource(type, selectedLanguage)} />
     </TermsOrPrivacyTemplate>
   );
 };

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components';
 import { useSnapshot } from 'valtio';
 
 import { LgtmImages } from '../../components';
@@ -19,6 +20,14 @@ import type {
   LgtmImage,
 } from '../../types';
 import type { FC } from 'react';
+
+const Wrapper = styled.div`
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 100%;
+  gap: 32px;
+  min-height: 100vh;
+`;
 
 type Props = {
   language: Language;
@@ -86,16 +95,18 @@ export const TopTemplate: FC<Props> = ({
         isLanguageMenuDisplayed={isLanguageMenuDisplayed}
         onClickLanguageButton={onClickLanguageButton}
       >
-        <AppDescriptionArea language={selectedLanguage} />
-        <CatButtonGroup
-          onClickFetchRandomCatButton={onClickFetchRandomCatButton}
-          onClickFetchNewArrivalCatButton={onClickFetchNewArrivalCatButton}
-        />
-        <LgtmImages
-          images={fetchedLgtmImagesList as LgtmImage[]}
-          appUrl={appUrl}
-          callback={clipboardMarkdownCallback}
-        />
+        <Wrapper>
+          <AppDescriptionArea language={selectedLanguage} />
+          <CatButtonGroup
+            onClickFetchRandomCatButton={onClickFetchRandomCatButton}
+            onClickFetchNewArrivalCatButton={onClickFetchNewArrivalCatButton}
+          />
+          <LgtmImages
+            images={fetchedLgtmImagesList as LgtmImage[]}
+            appUrl={appUrl}
+            callback={clipboardMarkdownCallback}
+          />
+        </Wrapper>
       </ResponsiveLayout>
     </div>
   );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/156

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/156 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-rgvjlzceoa.chromatic.com/?path=/story/src-templates-toptemplate-toptemplate-tsx--view-in-japanese

# 変更点概要

paddingの設定がFigmaのデザイン通りになっていない箇所があったので修正。

ちなみにこの修正でもErrorTemplateなどは中央に配置出来ていないので、厳密にはまだデザイン通りではないが、これはそれなりに改修コストがかかるので、別の機会に実施する。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
