### PR TITLE
トップページのデザイン崩れ修正のため、CSSを調整

### DIFF
--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -26,7 +26,6 @@ const Wrapper = styled.div`
   grid-template-rows: auto 1fr auto;
   grid-template-columns: 100%;
   gap: 32px;
-  min-height: 100vh;
 `;
 
 type Props = {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/159

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/159 の現象が解消されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-kobyoiysrq.chromatic.com/?path=/story/src-templates-toptemplate-toptemplate-tsx--view-in-japanese

# 変更点概要

表題の通り。

`src/templates/TopTemplate/TopTemplate.tsx` に記載されていた `min-height: 100vh;` が原因でブラウザ幅を下に広げた際に空白部分が固定されてしまっていたのが原因となる。

Storybook上だと変化が分かりにくいが、https://62729802bbcc7d004a663d4c-kobyoiysrq.chromatic.com/?path=/story/src-templates-toptemplate-toptemplate-tsx--view-in-japanese でブラウザ幅を調整すると直っている事が確認出来る。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。