### PR TITLE
GA、GTMでのイベント計測用カスタムデータ属性を追加

### DIFF
--- a/src/components/Button/CatButtonGroup/CatButtonGroup.tsx
+++ b/src/components/Button/CatButtonGroup/CatButtonGroup.tsx
@@ -42,9 +42,20 @@ export const CatButtonGroup: FC<Props> = ({
 }) => (
   <Wrapper>
     <ButtonGroup>
-      <UploadCatButton link="/upload" />
-      <CatFetchButton type="refresh" onClick={onClickFetchRandomCatButton} />
-      <CatFetchButton type="new" onClick={onClickFetchNewArrivalCatButton} />
+      <UploadCatButton
+        link="/upload"
+        customDataAttrGtmClick="top-upload-cat-button"
+      />
+      <CatFetchButton
+        type="refresh"
+        onClick={onClickFetchRandomCatButton}
+        customDataAttrGtmClick="top-fetch-random-cat-button"
+      />
+      <CatFetchButton
+        type="new"
+        onClick={onClickFetchNewArrivalCatButton}
+        customDataAttrGtmClick="top-fetch-new-arrival-cat-button"
+      />
     </ButtonGroup>
   </Wrapper>
 );

--- a/src/components/Button/CatFetchButton/CatFetchButton.tsx
+++ b/src/components/Button/CatFetchButton/CatFetchButton.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { mixins } from '../../../styles/mixins';
 import assertNever from '../../../utils/assertNever';
 
+import type { CustomDataAttrGtmClick } from '../../../types/gtm';
 import type { FC } from 'react';
 
 const StyledButton = styled.button`
@@ -42,10 +43,15 @@ type ButtonType = 'refresh' | 'new';
 type Props = {
   type: ButtonType;
   onClick: () => Promise<void>;
+  customDataAttrGtmClick?: CustomDataAttrGtmClick;
 };
 
-export const CatFetchButton: FC<Props> = ({ type, onClick }) => (
-  <StyledButton onClick={onClick}>
+export const CatFetchButton: FC<Props> = ({
+  type,
+  onClick,
+  customDataAttrGtmClick,
+}) => (
+  <StyledButton onClick={onClick} data-gtm-click={customDataAttrGtmClick}>
     <FaSyncAlt style={faSyncAltStyle} />
     <Text>{buttonText(type)}</Text>
   </StyledButton>

--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { mixins } from '../../../styles/mixins';
 import slash from '../images/slash.png';
 
+import type { CustomDataAttrGtmClick } from '../../../types/gtm';
 import type { FC } from 'react';
 
 const StyledSpan = styled.span`
@@ -29,11 +30,15 @@ const faCloudUploadAltStyle = {
 
 type Props = {
   link: `/${string}`;
+  customDataAttrGtmClick?: CustomDataAttrGtmClick;
 };
 
-export const UploadCatButton: FC<Props> = ({ link }) => (
+export const UploadCatButton: FC<Props> = ({
+  link,
+  customDataAttrGtmClick,
+}) => (
   <Link href={link} prefetch={false}>
-    <StyledSpan>
+    <StyledSpan data-gtm-click={customDataAttrGtmClick}>
       <FaCloudUploadAlt style={faCloudUploadAltStyle} />
       <Text>Upload new Cats</Text>
     </StyledSpan>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { createLinksFromLanguages as createPrivacyLinksFromLanguages } from '../../features/privacyPolicy';
 import { createLinksFromLanguages as createTermsLinksFromLanguages } from '../../features/termsOfUse';
-import { Language } from '../../types/language';
+import { Language } from '../../types';
 
 import type { FC } from 'react';
 
@@ -115,12 +115,20 @@ export const Footer: FC<Props> = ({ language }) => {
   return (
     <StyledFooter>
       <UpperSection>
-        <Link href={terms.link} prefetch={false}>
+        <Link
+          href={terms.link}
+          prefetch={false}
+          data-gtm-click="footer-terms-link"
+        >
           <TermsLinkText>{terms.text}</TermsLinkText>
         </Link>
         {/* eslint-disable no-irregular-whitespace */}
         <SeparatorText> / </SeparatorText>
-        <Link href={privacy.link} prefetch={false}>
+        <Link
+          href={privacy.link}
+          prefetch={false}
+          data-gtm-click="footer-privacy-link"
+        >
           <PrivacyLinkText>{privacy.text}</PrivacyLinkText>
         </Link>
       </UpperSection>

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -99,6 +99,7 @@ export type Props = {
   onClickCloseButton: () => void;
 };
 
+// eslint-disable-next-line max-lines-per-function
 export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
   const termsOfUseLinks = createTermsOfUseLinks(language);
 
@@ -107,19 +108,26 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
   return (
     <Wrapper>
       <HeaderWrapper>
-        <FaTimesWrapper onClick={onClickCloseButton}>
+        <FaTimesWrapper
+          onClick={onClickCloseButton}
+          data-gtm-click="global-menu-close-button"
+        >
           <FaTimes style={faTimesStyle} />
         </FaTimesWrapper>
       </HeaderWrapper>
       <LinkGroupWrapper>
         <LinkWrapper>
-          <Link href="/" prefetch={false}>
+          <Link href="/" prefetch={false} data-gtm-click="global-menu-top-link">
             <LinkText>TOP</LinkText>
           </Link>
           <UnderLine />
         </LinkWrapper>
         <LinkWrapper>
-          <Link href="/upload" prefetch={false}>
+          <Link
+            href="/upload"
+            prefetch={false}
+            data-gtm-click="global-menu-upload-cat-link"
+          >
             <LinkText>
               <FaCloudUploadAlt style={faCloudUploadAltStyle} />
               Upload new Cats
@@ -128,13 +136,21 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
           <UnderLine />
         </LinkWrapper>
         <LinkWrapper>
-          <Link href={termsOfUseLinks.link} prefetch={false}>
+          <Link
+            href={termsOfUseLinks.link}
+            prefetch={false}
+            data-gtm-click="global-menu-terms-link"
+          >
             <LinkText>{termsOfUseLinks.text}</LinkText>
           </Link>
           <UnderLine />
         </LinkWrapper>
         <LinkWrapper>
-          <Link href={privacyPolicyLinks.link} prefetch={false}>
+          <Link
+            href={privacyPolicyLinks.link}
+            prefetch={false}
+            data-gtm-click="global-menu-terms-link"
+          >
             <LinkText>{privacyPolicyLinks.text}</LinkText>
           </Link>
           <UnderLine />

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -102,7 +102,7 @@ export const Header: FC<Props> = ({
       <Wrapper>
         <StyledHeader>
           <FaBars style={faBarsStyle} onClick={openMenu} />
-          <Link href="/" prefetch={false}>
+          <Link href="/" prefetch={false} data-gtm-click="header-app-title">
             <Title>LGTMeow</Title>
           </Link>
           <LanguageButton onClick={onClickLanguageButton} />

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -1,7 +1,7 @@
 import { FaAngleRight } from 'react-icons/fa';
 import styled, { css } from 'styled-components';
 
-import { Language } from '../../types/language';
+import { Language } from '../../types';
 
 import type { FC, MouseEvent } from 'react';
 
@@ -84,21 +84,21 @@ const JaText = styled.div`
 
 export type Props = {
   language: Language;
-  onClickEn: (event: MouseEvent<HTMLDivElement>) => void;
-  onClickJa: (event: MouseEvent<HTMLDivElement>) => void;
+  onClickEn: (event: MouseEvent<HTMLButtonElement>) => void;
+  onClickJa: (event: MouseEvent<HTMLButtonElement>) => void;
 };
 
 export const LanguageMenu: FC<Props> = ({ language, onClickEn, onClickJa }) => (
   <StyledLanguageMenu>
-    <EnTextWrapper>
-      <EnText onClick={onClickEn}>
+    <EnTextWrapper onClick={onClickEn} data-gtm-click="language-menu-en-button">
+      <EnText>
         {language === 'en' ? <FaAngleRight /> : ''}
         English
       </EnText>
     </EnTextWrapper>
     <Separator />
-    <JaTextWrapper>
-      <JaText onClick={onClickJa}>
+    <JaTextWrapper onClick={onClickJa} data-gtm-click="language-menu-ja-button">
+      <JaText>
         {language === 'ja' ? <FaAngleRight /> : ''}
         日本語
       </JaText>

--- a/src/components/LgtmImages/LgtmImageContent.tsx
+++ b/src/components/LgtmImages/LgtmImageContent.tsx
@@ -39,7 +39,11 @@ export const LgtmImageContent: FC<Props> = ({
   });
 
   return (
-    <ImageWrapper key={id} ref={imageContextRef}>
+    <ImageWrapper
+      key={id}
+      ref={imageContextRef}
+      data-gtm-click="copy-markdown-from-top-images"
+    >
       <Image
         src={imageUrl}
         layout="fill"

--- a/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
+++ b/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { AppUrl, defaultAppUrl } from '../../../constants/url';
 import useClipboardMarkdown from '../../../hooks/useClipboardMarkdown';
 import { useCopySuccess } from '../../../hooks/useCopySuccess';
-import { LgtmImageUrl } from '../../../types/lgtmImage';
+import { LgtmImageUrl } from '../../../types';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
 
 import type { FC } from 'react';
@@ -48,7 +48,10 @@ export const CreatedLgtmImage: FC<Props> = ({
 
   return (
     <>
-      <Wrapper ref={imageContextRef}>
+      <Wrapper
+        ref={imageContextRef}
+        data-gtm-click="copy-markdown-from-created-image"
+      >
         <StyledImage src={imagePreviewUrl} />
       </Wrapper>
       {copied ? <CopiedGithubMarkdownMessage /> : ''}

--- a/src/components/Upload/UploadModal/SuccessMessageArea.tsx
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.tsx
@@ -270,7 +270,10 @@ export const SuccessMessageArea: FC<Props> = ({
             <CloseButton onClick={onClickClose}>
               <CloseButtonText>{closeButtonText(language)}</CloseButtonText>
             </CloseButton>
-            <MarkdownSourceCopyButton ref={imageContextRef}>
+            <MarkdownSourceCopyButton
+              ref={imageContextRef}
+              data-gtm-click="copy-markdown-from-copy-button"
+            >
               <MarkdownSourceCopyButtonText>
                 {markdownSourceCopyButtonText(language)}
               </MarkdownSourceCopyButtonText>

--- a/src/hooks/useSwitchLanguage.ts
+++ b/src/hooks/useSwitchLanguage.ts
@@ -24,7 +24,7 @@ export const useSwitchLanguage = (
   const selectedLanguage = snap.language ? snap.language : language;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onClickEn = (event: MouseEvent<HTMLDivElement>) => {
+  const onClickEn = (event: MouseEvent<HTMLButtonElement>) => {
     updateLanguage(languageEn);
 
     if (changeLanguageCallback) {
@@ -33,7 +33,7 @@ export const useSwitchLanguage = (
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onClickJa = (event: MouseEvent<HTMLDivElement>) => {
+  const onClickJa = (event: MouseEvent<HTMLButtonElement>) => {
     updateLanguage(languageJa);
 
     if (changeLanguageCallback) {

--- a/src/types/gtm.ts
+++ b/src/types/gtm.ts
@@ -1,0 +1,8 @@
+export type CustomDataAttrGtmClick =
+  | 'top-upload-cat-button'
+  | 'top-fetch-random-cat-button'
+  | 'top-fetch-new-arrival-cat-button'
+  | 'language-menu-ja-button'
+  | 'language-menu-en-button'
+  | 'footer-terms-link'
+  | 'footer-privacy-link';

--- a/src/types/gtm.ts
+++ b/src/types/gtm.ts
@@ -1,8 +1,18 @@
 export type CustomDataAttrGtmClick =
+  | 'header-app-title'
   | 'top-upload-cat-button'
   | 'top-fetch-random-cat-button'
   | 'top-fetch-new-arrival-cat-button'
   | 'language-menu-ja-button'
   | 'language-menu-en-button'
   | 'footer-terms-link'
-  | 'footer-privacy-link';
+  | 'footer-privacy-link'
+  | 'global-menu-top-link'
+  | 'global-menu-upload-cat-link'
+  | 'global-menu-terms-link'
+  | 'global-menu-privacy-link'
+  | 'global-menu-open-button'
+  | 'global-menu-close-button'
+  | 'copy-markdown-from-top-images'
+  | 'copy-markdown-from-created-image'
+  | 'copy-markdown-from-copy-button';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/153

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/153 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-wtzuwohzxt.chromatic.com/

# 変更点概要

GAで計測したいと思われる箇所に `data-gtm-click` というカスタムデータ属性を追加。

目的としては以下の記事にあるようにGTM、GA4でイベントの計測を行うため。

https://zenn.dev/keitakn/scraps/1b0bdea51150e7

アップロードに関しては、カスタムイベントを送信したほうが良いので、カスタムデータ属性の追加は行っていない。

# レビュアーに重点的にチェックして欲しい点

今回計測のターゲットにしたのは以下の通りなんだけど、これで問題ないか確認してもらえると:pray:
（これでUIのどの部分がよく使われるかはある程度分かる気はする）

```
header-app-title
top-upload-cat-button
top-fetch-random-cat-button
top-fetch-new-arrival-cat-button
language-menu-ja-button
language-menu-en-button
footer-terms-link
footer-privacy-link
global-menu-top-link
global-menu-upload-cat-link
global-menu-terms-link
global-menu-privacy-link
global-menu-open-button
global-menu-close-button
copy-markdown-from-top-images
copy-markdown-from-created-image
copy-markdown-from-copy-button
```

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。