### PR TITLE
data-gtm-clickのリファクタリング

### DIFF
--- a/src/components/Button/CatButtonGroup/CatButtonGroup.tsx
+++ b/src/components/Button/CatButtonGroup/CatButtonGroup.tsx
@@ -46,16 +46,8 @@ export const CatButtonGroup: FC<Props> = ({
         link="/upload"
         customDataAttrGtmClick="top-upload-cat-button"
       />
-      <CatFetchButton
-        type="refresh"
-        onClick={onClickFetchRandomCatButton}
-        customDataAttrGtmClick="top-fetch-random-cat-button"
-      />
-      <CatFetchButton
-        type="new"
-        onClick={onClickFetchNewArrivalCatButton}
-        customDataAttrGtmClick="top-fetch-new-arrival-cat-button"
-      />
+      <CatFetchButton type="refresh" onClick={onClickFetchRandomCatButton} />
+      <CatFetchButton type="new" onClick={onClickFetchNewArrivalCatButton} />
     </ButtonGroup>
   </Wrapper>
 );

--- a/src/components/Button/CatFetchButton/CatFetchButton.tsx
+++ b/src/components/Button/CatFetchButton/CatFetchButton.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { mixins } from '../../../styles/mixins';
 import assertNever from '../../../utils/assertNever';
 
-import type { CustomDataAttrGtmClick } from '../../../types/gtm';
 import type { FC } from 'react';
 
 const StyledButton = styled.button`
@@ -43,15 +42,10 @@ type ButtonType = 'refresh' | 'new';
 type Props = {
   type: ButtonType;
   onClick: () => Promise<void>;
-  customDataAttrGtmClick?: CustomDataAttrGtmClick;
 };
 
-export const CatFetchButton: FC<Props> = ({
-  type,
-  onClick,
-  customDataAttrGtmClick,
-}) => (
-  <StyledButton onClick={onClick} data-gtm-click={customDataAttrGtmClick}>
+export const CatFetchButton: FC<Props> = ({ type, onClick }) => (
+  <StyledButton onClick={onClick}>
     <FaSyncAlt style={faSyncAltStyle} />
     <Text>{buttonText(type)}</Text>
   </StyledButton>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -115,21 +115,17 @@ export const Footer: FC<Props> = ({ language }) => {
   return (
     <StyledFooter>
       <UpperSection>
-        <Link
-          href={terms.link}
-          prefetch={false}
-          data-gtm-click="footer-terms-link"
-        >
-          <TermsLinkText>{terms.text}</TermsLinkText>
+        <Link href={terms.link} prefetch={false}>
+          <TermsLinkText data-gtm-click="footer-terms-link">
+            {terms.text}
+          </TermsLinkText>
         </Link>
         {/* eslint-disable no-irregular-whitespace */}
         <SeparatorText> / </SeparatorText>
-        <Link
-          href={privacy.link}
-          prefetch={false}
-          data-gtm-click="footer-privacy-link"
-        >
-          <PrivacyLinkText>{privacy.text}</PrivacyLinkText>
+        <Link href={privacy.link} prefetch={false}>
+          <PrivacyLinkText data-gtm-click="footer-privacy-link">
+            {privacy.text}
+          </PrivacyLinkText>
         </Link>
       </UpperSection>
       <LowerSection>

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -117,18 +117,14 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
       </HeaderWrapper>
       <LinkGroupWrapper>
         <LinkWrapper>
-          <Link href="/" prefetch={false} data-gtm-click="global-menu-top-link">
-            <LinkText>TOP</LinkText>
+          <Link href="/" prefetch={false}>
+            <LinkText data-gtm-click="global-menu-top-link">TOP</LinkText>
           </Link>
           <UnderLine />
         </LinkWrapper>
         <LinkWrapper>
-          <Link
-            href="/upload"
-            prefetch={false}
-            data-gtm-click="global-menu-upload-cat-link"
-          >
-            <LinkText>
+          <Link href="/upload" prefetch={false}>
+            <LinkText data-gtm-click="global-menu-upload-cat-link">
               <FaCloudUploadAlt style={faCloudUploadAltStyle} />
               Upload new Cats
             </LinkText>
@@ -136,22 +132,18 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
           <UnderLine />
         </LinkWrapper>
         <LinkWrapper>
-          <Link
-            href={termsOfUseLinks.link}
-            prefetch={false}
-            data-gtm-click="global-menu-terms-link"
-          >
-            <LinkText>{termsOfUseLinks.text}</LinkText>
+          <Link href={termsOfUseLinks.link} prefetch={false}>
+            <LinkText data-gtm-click="global-menu-terms-link">
+              {termsOfUseLinks.text}
+            </LinkText>
           </Link>
           <UnderLine />
         </LinkWrapper>
         <LinkWrapper>
-          <Link
-            href={privacyPolicyLinks.link}
-            prefetch={false}
-            data-gtm-click="global-menu-terms-link"
-          >
-            <LinkText>{privacyPolicyLinks.text}</LinkText>
+          <Link href={privacyPolicyLinks.link} prefetch={false}>
+            <LinkText data-gtm-click="global-menu-terms-link">
+              {privacyPolicyLinks.text}
+            </LinkText>
           </Link>
           <UnderLine />
         </LinkWrapper>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -102,8 +102,8 @@ export const Header: FC<Props> = ({
       <Wrapper>
         <StyledHeader>
           <FaBars style={faBarsStyle} onClick={openMenu} />
-          <Link href="/" prefetch={false} data-gtm-click="header-app-title">
-            <Title>LGTMeow</Title>
+          <Link href="/" prefetch={false}>
+            <Title data-gtm-click="header-app-title">LGTMeow</Title>
           </Link>
           <LanguageButton onClick={onClickLanguageButton} />
           {isLanguageMenuDisplayed ? (

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -90,14 +90,14 @@ export type Props = {
 
 export const LanguageMenu: FC<Props> = ({ language, onClickEn, onClickJa }) => (
   <StyledLanguageMenu>
-    <EnTextWrapper onClick={onClickEn} data-gtm-click="language-menu-en-button">
+    <EnTextWrapper onClick={onClickEn}>
       <EnText>
         {language === 'en' ? <FaAngleRight /> : ''}
         English
       </EnText>
     </EnTextWrapper>
     <Separator />
-    <JaTextWrapper onClick={onClickJa} data-gtm-click="language-menu-ja-button">
+    <JaTextWrapper onClick={onClickJa}>
       <JaText>
         {language === 'ja' ? <FaAngleRight /> : ''}
         日本語

--- a/src/components/LgtmImages/LgtmImageContent.tsx
+++ b/src/components/LgtmImages/LgtmImageContent.tsx
@@ -39,11 +39,7 @@ export const LgtmImageContent: FC<Props> = ({
   });
 
   return (
-    <ImageWrapper
-      key={id}
-      ref={imageContextRef}
-      data-gtm-click="copy-markdown-from-top-images"
-    >
+    <ImageWrapper key={id} ref={imageContextRef}>
       <Image
         src={imageUrl}
         layout="fill"

--- a/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
+++ b/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
@@ -48,10 +48,7 @@ export const CreatedLgtmImage: FC<Props> = ({
 
   return (
     <>
-      <Wrapper
-        ref={imageContextRef}
-        data-gtm-click="copy-markdown-from-created-image"
-      >
+      <Wrapper ref={imageContextRef}>
         <StyledImage src={imagePreviewUrl} />
       </Wrapper>
       {copied ? <CopiedGithubMarkdownMessage /> : ''}

--- a/src/components/Upload/UploadModal/SuccessMessageArea.tsx
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.tsx
@@ -270,10 +270,7 @@ export const SuccessMessageArea: FC<Props> = ({
             <CloseButton onClick={onClickClose}>
               <CloseButtonText>{closeButtonText(language)}</CloseButtonText>
             </CloseButton>
-            <MarkdownSourceCopyButton
-              ref={imageContextRef}
-              data-gtm-click="copy-markdown-from-copy-button"
-            >
+            <MarkdownSourceCopyButton ref={imageContextRef}>
               <MarkdownSourceCopyButtonText>
                 {markdownSourceCopyButtonText(language)}
               </MarkdownSourceCopyButtonText>

--- a/src/types/gtm.ts
+++ b/src/types/gtm.ts
@@ -1,10 +1,6 @@
 export type CustomDataAttrGtmClick =
   | 'header-app-title'
   | 'top-upload-cat-button'
-  | 'top-fetch-random-cat-button'
-  | 'top-fetch-new-arrival-cat-button'
-  | 'language-menu-ja-button'
-  | 'language-menu-en-button'
   | 'footer-terms-link'
   | 'footer-privacy-link'
   | 'global-menu-top-link'
@@ -12,7 +8,4 @@ export type CustomDataAttrGtmClick =
   | 'global-menu-terms-link'
   | 'global-menu-privacy-link'
   | 'global-menu-open-button'
-  | 'global-menu-close-button'
-  | 'copy-markdown-from-top-images'
-  | 'copy-markdown-from-created-image'
-  | 'copy-markdown-from-copy-button';
+  | 'global-menu-close-button';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/153

# Done の定義

- next/link に data-gtm-click をつけても消えてしまうので直接その配下の<a> タグにつけるように変更されている事
- 単純なリンククリック以外はcustomイベントを使う方針としたので data-gtm-click が削除されている事

# スクリーンショット or Storybook の URL

UI変更がないので今回はなし

# 変更点概要

以下の方針でリファクタリングを実施。

1. next/link に data-gtm-click をつけても消えてしまうので直接その配下の<a> タグにつけるように変更
2. 単純なリンククリック以外はcustomイベントを使う方針としたので data-gtm-click を削除

`2` の理由としてはGTM上のカスタムデータを使った計測が安定しない事があり、Reactが生成するVirtualDOMの形が変わった際に計測出来なくなる可能性もゼロではないので、より確実なカスタムイベントを送信する形に変更する。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

今までのカスタムイベントを使う計測方法と https://zenn.dev/keitakn/scraps/1b0bdea51150e7 のカスタムデータ属性を使う方法が2つ混在するようになるイメージ🐱

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
