### PR TITLE
data-gtm-click属性の調整

### DIFF
--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -39,8 +39,11 @@ export const UploadCatButton: FC<Props> = ({
 }) => (
   <Link href={link} prefetch={false}>
     <StyledSpan data-gtm-click={customDataAttrGtmClick}>
-      <FaCloudUploadAlt style={faCloudUploadAltStyle} />
-      <Text>Upload new Cats</Text>
+      <FaCloudUploadAlt
+        style={faCloudUploadAltStyle}
+        data-gtm-click={customDataAttrGtmClick}
+      />
+      <Text data-gtm-click={customDataAttrGtmClick}>Upload new Cats</Text>
     </StyledSpan>
   </Link>
 );

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -108,10 +108,7 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
   return (
     <Wrapper>
       <HeaderWrapper>
-        <FaTimesWrapper
-          onClick={onClickCloseButton}
-          data-gtm-click="global-menu-close-button"
-        >
+        <FaTimesWrapper onClick={onClickCloseButton}>
           <FaTimes style={faTimesStyle} />
         </FaTimesWrapper>
       </HeaderWrapper>

--- a/src/types/gtm.ts
+++ b/src/types/gtm.ts
@@ -6,6 +6,4 @@ export type CustomDataAttrGtmClick =
   | 'global-menu-top-link'
   | 'global-menu-upload-cat-link'
   | 'global-menu-terms-link'
-  | 'global-menu-privacy-link'
-  | 'global-menu-open-button'
-  | 'global-menu-close-button';
+  | 'global-menu-privacy-link';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/153

# Done の定義

- 不要なデータ属性が削除されている事
- GA上で集計出来ないデータ属性があるので修正されている事

# スクリーンショット or Storybook の URL

UI変更はないのでなし

# 変更点概要

- top-upload-cat-button が反応しないので子要素全てにデータ属性を追加
- グローバルメニューの開閉はイベントとして計測する意味が薄いので削除

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
