### PR TITLE
アップロード中にThrowされたErrorはState更新後にそのままThrowするように変更

### DIFF
--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -204,7 +204,7 @@ export const UploadForm: FC<Props> = ({
     openModal();
   };
 
-  // eslint-disable-next-line max-statements
+  // eslint-disable-next-line max-statements, max-lines-per-function
   const executeUpload = async () => {
     setIsLoading(true);
 
@@ -251,6 +251,10 @@ export const UploadForm: FC<Props> = ({
     } catch (error) {
       setDisplayErrorMessages(unexpectedErrorMessage(language));
       stateInitAtError();
+
+      if (error instanceof Error) {
+        throw error;
+      }
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/169

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/169 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

![Error](https://user-images.githubusercontent.com/11032365/189661829-014ad913-fa8d-43f1-b7e6-884a669e39d3.png)

# 変更点概要

表題の通り、これでアップロード中の例外もSentryに通知されるようになる。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
