### PR TITLE
複数環境での動作を想定しUploadTemplateでappUrlを受け取れるように変更

### DIFF
--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, type FC, FormEvent, ChangeEvent } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { FaCloudUploadAlt } from 'react-icons/fa';
 
+import { AppUrl } from '../../../constants/url';
 import {
   isValidFileType,
   extractImageExtFromValidFileType,
@@ -96,6 +97,7 @@ export type Props = {
   uploadCallback?: () => void;
   onClickCreatedLgtmImage?: () => void;
   onClickMarkdownSourceCopyButton?: () => void;
+  appUrl?: AppUrl;
 };
 
 // eslint-disable-next-line max-lines-per-function, max-statements
@@ -106,6 +108,7 @@ export const UploadForm: FC<Props> = ({
   uploadCallback,
   onClickCreatedLgtmImage,
   onClickMarkdownSourceCopyButton,
+  appUrl,
 }) => {
   const [base64Image, setBase64Image] = useState<string>('');
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string>('');
@@ -331,6 +334,7 @@ export const UploadForm: FC<Props> = ({
           createdLgtmImageUrl={createdLgtmImageUrl}
           onClickCreatedLgtmImage={onClickCreatedLgtmImage}
           onClickMarkdownSourceCopyButton={onClickMarkdownSourceCopyButton}
+          appUrl={appUrl}
         />
       ) : (
         ''

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -1,8 +1,6 @@
 import Modal from 'react-modal';
 import styled from 'styled-components';
 
-import { Language } from '../../../types/language';
-import { LgtmImageUrl } from '../../../types/lgtmImage';
 import assertNever from '../../../utils/assertNever';
 import { UploadProgressBar } from '../UploadProgressBar';
 
@@ -10,6 +8,8 @@ import { ButtonGroup } from './ButtonGroup';
 import { CreatedLgtmImage } from './CreatedLgtmImage';
 import { SuccessMessageArea } from './SuccessMessageArea';
 
+import type { AppUrl } from '../../../constants/url';
+import type { Language, LgtmImageUrl } from '../../../types';
 import type { FC } from 'react';
 
 export type Props = {
@@ -24,6 +24,7 @@ export type Props = {
   uploaded?: boolean;
   onClickCreatedLgtmImage?: () => void;
   onClickMarkdownSourceCopyButton?: () => void;
+  appUrl?: AppUrl;
 };
 
 const Wrapper = styled.div`
@@ -157,6 +158,7 @@ export const UploadModal: FC<Props> = ({
   createdLgtmImageUrl,
   onClickCreatedLgtmImage,
   onClickMarkdownSourceCopyButton,
+  appUrl,
 }) => {
   if (uploaded) {
     modalStyle.content.height = '705px';
@@ -180,6 +182,7 @@ export const UploadModal: FC<Props> = ({
                 imagePreviewUrl={imagePreviewUrl}
                 createdLgtmImageUrl={createdLgtmImageUrl}
                 callback={onClickCreatedLgtmImage}
+                appUrl={appUrl}
               />
             ) : (
               <PreviewImageWrapper>

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -203,6 +203,7 @@ export const UploadModal: FC<Props> = ({
               createdLgtmImageUrl={createdLgtmImageUrl}
               onClickClose={onClickClose}
               callback={onClickMarkdownSourceCopyButton}
+              appUrl={appUrl}
             />
           ) : (
             ''

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -55,6 +55,8 @@ const onClickMarkdownSourceCopyButton = () =>
   // eslint-disable-next-line no-console
   console.log('onClickMarkdownSourceCopyButton executed!');
 
+const appUrl = 'http://localhost:2222';
+
 export default {
   title: 'src/templates/UploadTemplate/UploadTemplate.tsx',
   component: UploadTemplate,
@@ -72,6 +74,7 @@ export const ViewInJapanese: Story = {
     uploadCallback,
     onClickCreatedLgtmImage,
     onClickMarkdownSourceCopyButton,
+    appUrl,
   },
 };
 
@@ -85,5 +88,6 @@ export const ViewInEnglish: Story = {
     uploadCallback,
     onClickCreatedLgtmImage,
     onClickMarkdownSourceCopyButton,
+    appUrl,
   },
 };

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { UploadForm } from '../../components';
+import { AppUrl } from '../../constants/url';
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
 import {
@@ -30,6 +31,7 @@ type Props = {
   uploadCallback?: () => void;
   onClickCreatedLgtmImage?: () => void;
   onClickMarkdownSourceCopyButton?: () => void;
+  appUrl?: AppUrl;
 };
 
 export const UploadTemplate: FC<Props> = ({
@@ -41,6 +43,7 @@ export const UploadTemplate: FC<Props> = ({
   uploadCallback,
   onClickCreatedLgtmImage,
   onClickMarkdownSourceCopyButton,
+  appUrl,
 }) => {
   const {
     isLanguageMenuDisplayed,
@@ -67,6 +70,7 @@ export const UploadTemplate: FC<Props> = ({
           uploadCallback={uploadCallback}
           onClickCreatedLgtmImage={onClickCreatedLgtmImage}
           onClickMarkdownSourceCopyButton={onClickMarkdownSourceCopyButton}
+          appUrl={appUrl}
         />
         <ImageWrapper>{catImage}</ImageWrapper>
       </ResponsiveLayout>


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/154

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/154 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

## 以下のようにMarkdownSourceの遷移先が渡したappUrlの物に変更されている

https://62729802bbcc7d004a663d4c-rphtwownty.chromatic.com/?path=/story/src-templates-uploadtemplate-uploadtemplate-tsx--view-in-japanese

[![LGTMeow](https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp)](http://localhost:2222)

# 変更点概要

表題の通り、本番運用には影響はないがプレビュー環境やステージング環境のURLを渡してMarkdownSourceの遷移先を変更出来るように改修した。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
