### PR TITLE
index.ts を使ってexportする形に統一し、export defaultの利用を辞めた

### DIFF
--- a/src/components/Button/CatFetchButton/CatFetchButton.stories.tsx
+++ b/src/components/Button/CatFetchButton/CatFetchButton.stories.tsx
@@ -1,4 +1,4 @@
-import { CatFetchButton } from './index';
+import { CatFetchButton } from '.';
 
 import type { ComponentStoryObj, Meta } from '@storybook/react';
 

--- a/src/components/Button/CatFetchButton/CatFetchButton.tsx
+++ b/src/components/Button/CatFetchButton/CatFetchButton.tsx
@@ -1,8 +1,8 @@
 import { FaSyncAlt } from 'react-icons/fa';
 import styled from 'styled-components';
 
-import { mixins } from '../../../styles/mixins';
-import { assertNever } from '../../../utils/assertNever';
+import { mixins } from '../../../styles';
+import { assertNever } from '../../../utils';
 
 import type { FC } from 'react';
 

--- a/src/components/Button/CatFetchButton/CatFetchButton.tsx
+++ b/src/components/Button/CatFetchButton/CatFetchButton.tsx
@@ -2,7 +2,7 @@ import { FaSyncAlt } from 'react-icons/fa';
 import styled from 'styled-components';
 
 import { mixins } from '../../../styles/mixins';
-import assertNever from '../../../utils/assertNever';
+import { assertNever } from '../../../utils/assertNever';
 
 import type { FC } from 'react';
 

--- a/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
+++ b/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
@@ -1,7 +1,7 @@
 import { FaRandom } from 'react-icons/fa';
 import styled from 'styled-components';
 
-import { mixins } from '../../../styles/mixins';
+import { mixins } from '../../../styles';
 import slash from '../images/slash.png';
 
 import type { FC, ComponentProps } from 'react';

--- a/src/components/Button/GitHubLoginButton/GitHubLoginButton.tsx
+++ b/src/components/Button/GitHubLoginButton/GitHubLoginButton.tsx
@@ -1,7 +1,7 @@
 import { FaGithub } from 'react-icons/fa';
 import styled from 'styled-components';
 
-import { mixins } from '../../../styles/mixins';
+import { mixins } from '../../../styles';
 
 import type { FC } from 'react';
 

--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -2,10 +2,10 @@ import Link from 'next/link';
 import { FaCloudUploadAlt } from 'react-icons/fa';
 import styled from 'styled-components';
 
-import { mixins } from '../../../styles/mixins';
+import { mixins } from '../../../styles';
 import slash from '../images/slash.png';
 
-import type { CustomDataAttrGtmClick } from '../../../types/gtm';
+import type { CustomDataAttrGtmClick } from '../../../types';
 import type { FC } from 'react';
 
 const StyledSpan = styled.span`

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,1 +1,3 @@
 export { CatRandomCopyButton } from './CatRandomCopyButton';
+export { UploadCatButton } from './UploadCatButton';
+export { CatButtonGroup } from './CatButtonGroup';

--- a/src/components/ErrorContent/BackToTopButton.tsx
+++ b/src/components/ErrorContent/BackToTopButton.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import styled from 'styled-components';
 
 import { Language } from '../../types';
-import assertNever from '../../utils/assertNever';
+import { assertNever } from '../../utils/assertNever';
 
 import type { FC } from 'react';
 

--- a/src/components/ErrorContent/BackToTopButton.tsx
+++ b/src/components/ErrorContent/BackToTopButton.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 import styled from 'styled-components';
 
-import { Language } from '../../types';
-import { assertNever } from '../../utils/assertNever';
+import { assertNever } from '../../utils';
 
+import type { Language } from '../../types';
 import type { FC } from 'react';
 
 const StyledSpan = styled.span`

--- a/src/components/ErrorContent/ErrorContent.tsx
+++ b/src/components/ErrorContent/ErrorContent.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { errorType, type ErrorType } from '../../features';
 import { Language } from '../../types';
-import assertNever from '../../utils/assertNever';
+import { assertNever } from '../../utils/assertNever';
 
 import { BackToTopButton } from './BackToTopButton';
 

--- a/src/components/ErrorContent/ErrorContent.tsx
+++ b/src/components/ErrorContent/ErrorContent.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
 import { errorType, type ErrorType } from '../../features';
-import { Language } from '../../types';
-import { assertNever } from '../../utils/assertNever';
+import { assertNever } from '../../utils';
 
 import { BackToTopButton } from './BackToTopButton';
 
+import type { Language } from '../../types';
 import type { FC, ReactNode } from 'react';
 
 const Wrapper = styled.div`

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,10 +1,12 @@
 import Link from 'next/link';
 import styled from 'styled-components';
 
-import { createPrivacyPolicyLinksFromLanguages } from '../../features/privacyPolicy';
-import { createTermsOfUseLinksFromLanguages } from '../../features/termsOfUse';
-import { Language } from '../../types';
+import {
+  createPrivacyPolicyLinksFromLanguages,
+  createTermsOfUseLinksFromLanguages,
+} from '../../features';
 
+import type { Language } from '../../types';
 import type { FC } from 'react';
 
 const StyledFooter = styled.div`

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import styled from 'styled-components';
 
-import { createLinksFromLanguages as createPrivacyLinksFromLanguages } from '../../features/privacyPolicy';
-import { createLinksFromLanguages as createTermsLinksFromLanguages } from '../../features/termsOfUse';
+import { createPrivacyPolicyLinksFromLanguages } from '../../features/privacyPolicy';
+import { createTermsOfUseLinksFromLanguages } from '../../features/termsOfUse';
 import { Language } from '../../types';
 
 import type { FC } from 'react';
@@ -108,9 +108,9 @@ export type Props = {
 };
 
 export const Footer: FC<Props> = ({ language }) => {
-  const terms = createTermsLinksFromLanguages(language);
+  const terms = createTermsOfUseLinksFromLanguages(language);
 
-  const privacy = createPrivacyLinksFromLanguages(language);
+  const privacy = createPrivacyPolicyLinksFromLanguages(language);
 
   return (
     <StyledFooter>

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 import { FaTimes, FaCloudUploadAlt } from 'react-icons/fa';
 import styled from 'styled-components';
 
-import { createLinksFromLanguages as createPrivacyPolicyLinks } from './../../features/privacyPolicy';
-import { createLinksFromLanguages as createTermsOfUseLinks } from './../../features/termsOfUse';
+import { createPrivacyPolicyLinksFromLanguages } from './../../features/privacyPolicy';
+import { createTermsOfUseLinksFromLanguages } from './../../features/termsOfUse';
 
 import type { Language } from '../../types';
 import type { FC } from 'react';
@@ -101,9 +101,9 @@ export type Props = {
 
 // eslint-disable-next-line max-lines-per-function
 export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
-  const termsOfUseLinks = createTermsOfUseLinks(language);
+  const termsOfUseLinks = createTermsOfUseLinksFromLanguages(language);
 
-  const privacyPolicyLinks = createPrivacyPolicyLinks(language);
+  const privacyPolicyLinks = createPrivacyPolicyLinksFromLanguages(language);
 
   return (
     <Wrapper>

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -2,8 +2,10 @@ import Link from 'next/link';
 import { FaTimes, FaCloudUploadAlt } from 'react-icons/fa';
 import styled from 'styled-components';
 
-import { createPrivacyPolicyLinksFromLanguages } from './../../features/privacyPolicy';
-import { createTermsOfUseLinksFromLanguages } from './../../features/termsOfUse';
+import {
+  createPrivacyPolicyLinksFromLanguages,
+  createTermsOfUseLinksFromLanguages,
+} from '../../features';
 
 import type { Language } from '../../types';
 import type { FC } from 'react';

--- a/src/components/LgtmImages/LgtmImageContent.tsx
+++ b/src/components/LgtmImages/LgtmImageContent.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import styled from 'styled-components';
 
 import { AppUrl, defaultAppUrl } from '../../constants/url';
-import useClipboardMarkdown from '../../hooks/useClipboardMarkdown';
+import { useClipboardMarkdown } from '../../hooks/useClipboardMarkdown';
 import { useCopySuccess } from '../../hooks/useCopySuccess';
 import { LgtmImage } from '../../types/lgtmImage';
 

--- a/src/components/LgtmImages/LgtmImageContent.tsx
+++ b/src/components/LgtmImages/LgtmImageContent.tsx
@@ -1,13 +1,12 @@
 import Image from 'next/image';
 import styled from 'styled-components';
 
-import { AppUrl, defaultAppUrl } from '../../constants/url';
-import { useClipboardMarkdown } from '../../hooks/useClipboardMarkdown';
-import { useCopySuccess } from '../../hooks/useCopySuccess';
-import { LgtmImage } from '../../types/lgtmImage';
+import { AppUrl, defaultAppUrl } from '../../constants';
+import { useClipboardMarkdown, useCopySuccess } from '../../hooks';
 
 import { CopiedGithubMarkdownMessage } from './CopiedGithubMarkdownMessage';
 
+import type { LgtmImage } from '../../types';
 import type { FC } from 'react';
 
 const ImageWrapper = styled.div`

--- a/src/components/LgtmImages/LgtmImages.stories.tsx
+++ b/src/components/LgtmImages/LgtmImages.stories.tsx
@@ -1,4 +1,4 @@
-import { LgtmImage } from '../../types/lgtmImage';
+import { LgtmImage } from '../../types';
 
 import { LgtmImages } from './';
 

--- a/src/components/LgtmImages/LgtmImages.tsx
+++ b/src/components/LgtmImages/LgtmImages.tsx
@@ -1,10 +1,9 @@
 import styled from 'styled-components';
 
-import { AppUrl } from '../../constants/url';
-import { LgtmImage } from '../../types/lgtmImage';
-
 import { LgtmImageContent } from './LgtmImageContent';
 
+import type { AppUrl } from '../../constants';
+import type { LgtmImage } from '../../types';
 import type { FC } from 'react';
 
 const Wrapper = styled.div`

--- a/src/components/Upload/UploadButton/UploadButton.tsx
+++ b/src/components/Upload/UploadButton/UploadButton.tsx
@@ -1,8 +1,8 @@
 import styled, { css } from 'styled-components';
 
-import { Language } from '../../../types/language';
-import { assertNever } from '../../../utils/assertNever';
+import { assertNever } from '../../../utils';
 
+import type { Language } from '../../../types';
 import type { FC, FormEventHandler } from 'react';
 
 const buttonCss = css`

--- a/src/components/Upload/UploadButton/UploadButton.tsx
+++ b/src/components/Upload/UploadButton/UploadButton.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from 'styled-components';
 
 import { Language } from '../../../types/language';
-import assertNever from '../../../utils/assertNever';
+import { assertNever } from '../../../utils/assertNever';
 
 import type { FC, FormEventHandler } from 'react';
 

--- a/src/components/Upload/UploadForm/UploadForm.stories.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.stories.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { createSuccessResult } from '../../../features/result';
-import { AcceptedTypesImageExtension } from '../../../types/lgtmImage';
-import { sleep } from '../../../utils/sleep';
+import { createSuccessResult } from '../../../features';
+import { sleep } from '../../../utils';
 
 import { UploadForm } from '.';
 
+import type { AcceptedTypesImageExtension } from '../../../types';
 import type { ComponentStoryObj, Meta } from '@storybook/react';
 
 export default {

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -17,7 +17,7 @@ import {
   LgtmImageUrl,
   Language,
 } from '../../../types';
-import assertNever from '../../../utils/assertNever';
+import { assertNever } from '../../../utils/assertNever';
 import { UploadButton } from '../UploadButton';
 import { UploadErrorMessageArea } from '../UploadErrorMessageArea';
 import { UploadModal } from '../UploadModal';

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -4,20 +4,12 @@ import { useState, useCallback, type FC, FormEvent, ChangeEvent } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { FaCloudUploadAlt } from 'react-icons/fa';
 
-import { AppUrl } from '../../../constants/url';
 import {
   isValidFileType,
   extractImageExtFromValidFileType,
-} from '../../../features/lgtmImage';
-import { createPrivacyPolicyLinksFromLanguages } from '../../../features/privacyPolicy';
-import {
-  AcceptedTypesImageExtension,
-  ImageUploader,
-  ImageValidator,
-  LgtmImageUrl,
-  Language,
-} from '../../../types';
-import { assertNever } from '../../../utils/assertNever';
+  createPrivacyPolicyLinksFromLanguages,
+} from '../../../features';
+import { assertNever } from '../../../utils';
 import { UploadButton } from '../UploadButton';
 import { UploadErrorMessageArea } from '../UploadErrorMessageArea';
 import { UploadModal } from '../UploadModal';
@@ -47,6 +39,15 @@ import {
   unexpectedErrorMessage,
   uploadInputButtonText,
 } from './i18n';
+
+import type { AppUrl } from '../../../constants';
+import type {
+  AcceptedTypesImageExtension,
+  ImageUploader,
+  ImageValidator,
+  LgtmImageUrl,
+  Language,
+} from '../../../types';
 
 const faCloudUploadAltStyle = {
   fontStyle: 'normal',

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -9,7 +9,7 @@ import {
   isValidFileType,
   extractImageExtFromValidFileType,
 } from '../../../features/lgtmImage';
-import { createLinksFromLanguages } from '../../../features/privacyPolicy';
+import { createPrivacyPolicyLinksFromLanguages } from '../../../features/privacyPolicy';
 import {
   AcceptedTypesImageExtension,
   ImageUploader,
@@ -62,7 +62,7 @@ const faCloudUploadAltStyle = {
 };
 
 export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
-  const privacyLinkAttribute = createLinksFromLanguages(language);
+  const privacyLinkAttribute = createPrivacyPolicyLinksFromLanguages(language);
 
   switch (language) {
     case 'ja':

--- a/src/components/Upload/UploadForm/i18n.ts
+++ b/src/components/Upload/UploadForm/i18n.ts
@@ -1,5 +1,5 @@
 import { Language } from '../../../types/language';
-import assertNever from '../../../utils/assertNever';
+import { assertNever } from '../../../utils/assertNever';
 
 export const imageDropAreaText = (language: Language): string => {
   switch (language) {

--- a/src/components/Upload/UploadForm/i18n.ts
+++ b/src/components/Upload/UploadForm/i18n.ts
@@ -1,5 +1,6 @@
-import { Language } from '../../../types/language';
-import { assertNever } from '../../../utils/assertNever';
+import { assertNever } from '../../../utils';
+
+import type { Language } from '../../../types';
 
 export const imageDropAreaText = (language: Language): string => {
   switch (language) {

--- a/src/components/Upload/UploadModal/ButtonGroup.tsx
+++ b/src/components/Upload/UploadModal/ButtonGroup.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { Language } from '../../../types/language';
-import assertNever from '../../../utils/assertNever';
+import { assertNever } from '../../../utils/assertNever';
 
 import type { FC } from 'react';
 

--- a/src/components/Upload/UploadModal/ButtonGroup.tsx
+++ b/src/components/Upload/UploadModal/ButtonGroup.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-import { Language } from '../../../types/language';
-import { assertNever } from '../../../utils/assertNever';
+import { assertNever } from '../../../utils';
 
+import type { Language } from '../../../types';
 import type { FC } from 'react';
 
 const Wrapper = styled.div`

--- a/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
+++ b/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { AppUrl, defaultAppUrl } from '../../../constants/url';
-import useClipboardMarkdown from '../../../hooks/useClipboardMarkdown';
+import { useClipboardMarkdown } from '../../../hooks/useClipboardMarkdown';
 import { useCopySuccess } from '../../../hooks/useCopySuccess';
 import { LgtmImageUrl } from '../../../types';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';

--- a/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
+++ b/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
 
-import { AppUrl, defaultAppUrl } from '../../../constants/url';
-import { useClipboardMarkdown } from '../../../hooks/useClipboardMarkdown';
-import { useCopySuccess } from '../../../hooks/useCopySuccess';
+import { defaultAppUrl, type AppUrl } from '../../../constants';
+import { useClipboardMarkdown, useCopySuccess } from '../../../hooks';
 import { LgtmImageUrl } from '../../../types';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
 

--- a/src/components/Upload/UploadModal/SuccessMessageArea.tsx
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { AppUrl, defaultAppUrl } from '../../../constants/url';
-import useClipboardMarkdown from '../../../hooks/useClipboardMarkdown';
+import { useClipboardMarkdown } from '../../../hooks/useClipboardMarkdown';
 import { useCopySuccess } from '../../../hooks/useCopySuccess';
 import { Language } from '../../../types/language';
 import { LgtmImageUrl } from '../../../types/lgtmImage';

--- a/src/components/Upload/UploadModal/SuccessMessageArea.tsx
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.tsx
@@ -5,7 +5,7 @@ import useClipboardMarkdown from '../../../hooks/useClipboardMarkdown';
 import { useCopySuccess } from '../../../hooks/useCopySuccess';
 import { Language } from '../../../types/language';
 import { LgtmImageUrl } from '../../../types/lgtmImage';
-import assertNever from '../../../utils/assertNever';
+import { assertNever } from '../../../utils/assertNever';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
 
 import type { FC } from 'react';

--- a/src/components/Upload/UploadModal/SuccessMessageArea.tsx
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.tsx
@@ -1,13 +1,11 @@
 import styled from 'styled-components';
 
-import { AppUrl, defaultAppUrl } from '../../../constants/url';
-import { useClipboardMarkdown } from '../../../hooks/useClipboardMarkdown';
-import { useCopySuccess } from '../../../hooks/useCopySuccess';
-import { Language } from '../../../types/language';
-import { LgtmImageUrl } from '../../../types/lgtmImage';
-import { assertNever } from '../../../utils/assertNever';
+import { defaultAppUrl, type AppUrl } from '../../../constants';
+import { useClipboardMarkdown, useCopySuccess } from '../../../hooks';
+import { assertNever } from '../../../utils';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
 
+import type { Language, LgtmImageUrl } from '../../../types';
 import type { FC } from 'react';
 
 const Wrapper = styled.div`

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -1,14 +1,14 @@
 import Modal from 'react-modal';
 import styled from 'styled-components';
 
-import { assertNever } from '../../../utils/assertNever';
+import { assertNever } from '../../../utils';
 import { UploadProgressBar } from '../UploadProgressBar';
 
 import { ButtonGroup } from './ButtonGroup';
 import { CreatedLgtmImage } from './CreatedLgtmImage';
 import { SuccessMessageArea } from './SuccessMessageArea';
 
-import type { AppUrl } from '../../../constants/url';
+import type { AppUrl } from '../../../constants';
 import type { Language, LgtmImageUrl } from '../../../types';
 import type { FC } from 'react';
 

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -1,7 +1,7 @@
 import Modal from 'react-modal';
 import styled from 'styled-components';
 
-import assertNever from '../../../utils/assertNever';
+import { assertNever } from '../../../utils/assertNever';
 import { UploadProgressBar } from '../UploadProgressBar';
 
 import { ButtonGroup } from './ButtonGroup';

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, type FC } from 'react';
 import styled from 'styled-components';
 
 import { Language } from '../../../types/language';
-import assertNever from '../../../utils/assertNever';
+import { assertNever } from '../../../utils/assertNever';
 
 const Wrapper = styled.div`
   flex: none;

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, type FC } from 'react';
 import styled from 'styled-components';
 
-import { Language } from '../../../types/language';
-import { assertNever } from '../../../utils/assertNever';
+import { assertNever } from '../../../utils';
+
+import type { Language } from '../../../types';
 
 const Wrapper = styled.div`
   flex: none;

--- a/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
+++ b/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
-import { Language } from '../../../types/language';
-import { assertNever } from '../../../utils/assertNever';
+import { Language } from '../../../types';
+import { assertNever } from '../../../utils';
 
 import type { FC } from 'react';
 

--- a/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
+++ b/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { Language } from '../../../types/language';
-import assertNever from '../../../utils/assertNever';
+import { assertNever } from '../../../utils/assertNever';
 
 import type { FC } from 'react';
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,3 +4,4 @@ export { LgtmImages } from './LgtmImages';
 export { UploadForm } from './Upload/UploadForm';
 export { CatRandomCopyButton } from './Button';
 export { ErrorContent, ErrorContentProps } from './ErrorContent';
+export { LibraryBooks } from './Icon/LibraryBooks';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export { defaultAppUrl, type AppUrl } from './url';

--- a/src/features/__tests__/lgtmImage/extractImageExtFromValidFileType.spec.ts
+++ b/src/features/__tests__/lgtmImage/extractImageExtFromValidFileType.spec.ts
@@ -1,4 +1,4 @@
-import NotAllowedImageExtensionError from '../../errors/NotAllowedImageExtensionError';
+import { NotAllowedImageExtensionError } from '../../errors/NotAllowedImageExtensionError';
 import { extractImageExtFromValidFileType } from '../../lgtmImage';
 
 describe('src/features/lgtmImage.ts extractImageExtFromValidFileType TestCase', () => {

--- a/src/features/__tests__/privacyPolicy/createLinksFromLanguages.spec.ts
+++ b/src/features/__tests__/privacyPolicy/createLinksFromLanguages.spec.ts
@@ -1,6 +1,6 @@
-import { createLinksFromLanguages } from '../../privacyPolicy';
+import { createPrivacyPolicyLinksFromLanguages } from '../../privacyPolicy';
 
-describe('src/features/privacyPolicy.ts createLinksFromLanguages TestCase', () => {
+describe('src/features/privacyPolicy.ts createPrivacyPolicyLinksFromLanguages TestCase', () => {
   it('should return an English link', () => {
     const language = 'en';
 
@@ -9,7 +9,9 @@ describe('src/features/privacyPolicy.ts createLinksFromLanguages TestCase', () =
       link: '/privacy',
     };
 
-    expect(createLinksFromLanguages(language)).toStrictEqual(expected);
+    expect(createPrivacyPolicyLinksFromLanguages(language)).toStrictEqual(
+      expected,
+    );
   });
 
   it('should return a Japanese link', () => {
@@ -20,6 +22,8 @@ describe('src/features/privacyPolicy.ts createLinksFromLanguages TestCase', () =
       link: '/privacy',
     };
 
-    expect(createLinksFromLanguages(language)).toStrictEqual(expected);
+    expect(createPrivacyPolicyLinksFromLanguages(language)).toStrictEqual(
+      expected,
+    );
   });
 });

--- a/src/features/__tests__/termsOfUse/createLinksFromLanguages.spec.ts
+++ b/src/features/__tests__/termsOfUse/createLinksFromLanguages.spec.ts
@@ -1,6 +1,6 @@
-import { createLinksFromLanguages } from '../../termsOfUse';
+import { createTermsOfUseLinksFromLanguages } from '../../termsOfUse';
 
-describe('src/features/termsOfUse.ts createLinksFromLanguages TestCase', () => {
+describe('src/features/termsOfUse.ts createTermsOfUseLinksFromLanguages TestCase', () => {
   it('should return an English link', () => {
     const language = 'en';
 
@@ -9,7 +9,9 @@ describe('src/features/termsOfUse.ts createLinksFromLanguages TestCase', () => {
       link: '/terms',
     };
 
-    expect(createLinksFromLanguages(language)).toStrictEqual(expected);
+    expect(createTermsOfUseLinksFromLanguages(language)).toStrictEqual(
+      expected,
+    );
   });
 
   it('should return a Japanese link', () => {
@@ -20,6 +22,8 @@ describe('src/features/termsOfUse.ts createLinksFromLanguages TestCase', () => {
       link: '/terms',
     };
 
-    expect(createLinksFromLanguages(language)).toStrictEqual(expected);
+    expect(createTermsOfUseLinksFromLanguages(language)).toStrictEqual(
+      expected,
+    );
   });
 });

--- a/src/features/errors/NotAllowedImageExtensionError.ts
+++ b/src/features/errors/NotAllowedImageExtensionError.ts
@@ -1,4 +1,4 @@
-export default class NotAllowedImageExtensionError extends Error {
+export class NotAllowedImageExtensionError extends Error {
   constructor(error?: string) {
     super(error);
     this.name = new.target.name;

--- a/src/features/errors/index.ts
+++ b/src/features/errors/index.ts
@@ -1,0 +1,3 @@
+export { NewArrivalCatImagesFetcherError } from './NewArrivalCatImagesFetcherError';
+export { NotAllowedImageExtensionError } from './NotAllowedImageExtensionError';
+export { RandomCatImagesFetcherError } from './RandomCatImagesFetcherError';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -9,3 +9,9 @@ export {
 } from './result';
 
 export { errorType, type ErrorType } from './error';
+
+export { isValidFileType, extractImageExtFromValidFileType } from './lgtmImage';
+
+export { createPrivacyPolicyLinksFromLanguages } from './privacyPolicy';
+
+export { createTermsOfUseLinksFromLanguages } from './termsOfUse';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -15,3 +15,9 @@ export { isValidFileType, extractImageExtFromValidFileType } from './lgtmImage';
 export { createPrivacyPolicyLinksFromLanguages } from './privacyPolicy';
 
 export { createTermsOfUseLinksFromLanguages } from './termsOfUse';
+
+export {
+  NewArrivalCatImagesFetcherError,
+  NotAllowedImageExtensionError,
+  RandomCatImagesFetcherError,
+} from './errors';

--- a/src/features/lgtmImage.ts
+++ b/src/features/lgtmImage.ts
@@ -1,6 +1,6 @@
-import { AcceptedTypesImageExtension } from '../types/lgtmImage';
+import { NotAllowedImageExtensionError } from './errors';
 
-import { NotAllowedImageExtensionError } from './errors/NotAllowedImageExtensionError';
+import type { AcceptedTypesImageExtension } from '../types';
 
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
 

--- a/src/features/lgtmImage.ts
+++ b/src/features/lgtmImage.ts
@@ -1,6 +1,6 @@
 import { AcceptedTypesImageExtension } from '../types/lgtmImage';
 
-import NotAllowedImageExtensionError from './errors/NotAllowedImageExtensionError';
+import { NotAllowedImageExtensionError } from './errors/NotAllowedImageExtensionError';
 
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
 

--- a/src/features/privacyPolicy.ts
+++ b/src/features/privacyPolicy.ts
@@ -1,6 +1,6 @@
 import { Language } from '../types/language';
 import { LinkAttribute } from '../types/link';
-import assertNever from '../utils/assertNever';
+import { assertNever } from '../utils/assertNever';
 
 export const createPrivacyPolicyLinksFromLanguages = (
   language: Language,

--- a/src/features/privacyPolicy.ts
+++ b/src/features/privacyPolicy.ts
@@ -1,6 +1,6 @@
-import { Language } from '../types/language';
-import { LinkAttribute } from '../types/link';
-import { assertNever } from '../utils/assertNever';
+import { assertNever } from '../utils';
+
+import type { Language, LinkAttribute } from '../types';
 
 export const createPrivacyPolicyLinksFromLanguages = (
   language: Language,

--- a/src/features/privacyPolicy.ts
+++ b/src/features/privacyPolicy.ts
@@ -2,7 +2,9 @@ import { Language } from '../types/language';
 import { LinkAttribute } from '../types/link';
 import assertNever from '../utils/assertNever';
 
-export const createLinksFromLanguages = (language: Language): LinkAttribute => {
+export const createPrivacyPolicyLinksFromLanguages = (
+  language: Language,
+): LinkAttribute => {
   const link = '/privacy';
 
   switch (language) {

--- a/src/features/termsOfUse.ts
+++ b/src/features/termsOfUse.ts
@@ -1,6 +1,6 @@
 import { Language } from '../types/language';
 import { LinkAttribute } from '../types/link';
-import assertNever from '../utils/assertNever';
+import { assertNever } from '../utils/assertNever';
 
 export const createTermsOfUseLinksFromLanguages = (
   language: Language,

--- a/src/features/termsOfUse.ts
+++ b/src/features/termsOfUse.ts
@@ -1,6 +1,6 @@
-import { Language } from '../types/language';
-import { LinkAttribute } from '../types/link';
-import { assertNever } from '../utils/assertNever';
+import { assertNever } from '../utils';
+
+import type { Language, LinkAttribute } from '../types';
 
 export const createTermsOfUseLinksFromLanguages = (
   language: Language,

--- a/src/features/termsOfUse.ts
+++ b/src/features/termsOfUse.ts
@@ -2,7 +2,9 @@ import { Language } from '../types/language';
 import { LinkAttribute } from '../types/link';
 import assertNever from '../utils/assertNever';
 
-export const createLinksFromLanguages = (language: Language): LinkAttribute => {
+export const createTermsOfUseLinksFromLanguages = (
+  language: Language,
+): LinkAttribute => {
   const link = '/terms';
 
   switch (language) {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,3 @@
 export { useSwitchLanguage } from './useSwitchLanguage';
+export { useClipboardMarkdown } from './useClipboardMarkdown';
+export { useCopySuccess } from './useCopySuccess';

--- a/src/hooks/useClipboardMarkdown.ts
+++ b/src/hooks/useClipboardMarkdown.ts
@@ -9,7 +9,7 @@ type Request = {
   appUrl: `http://${string}` | `https://${string}`;
 };
 
-const useClipboardMarkdown = ({
+export const useClipboardMarkdown = ({
   onCopySuccess,
   imageUrl,
   appUrl,
@@ -32,5 +32,3 @@ const useClipboardMarkdown = ({
 
   return { imageContextRef: ref };
 };
-
-export default useClipboardMarkdown;

--- a/src/hooks/useClipboardMarkdown.ts
+++ b/src/hooks/useClipboardMarkdown.ts
@@ -1,7 +1,7 @@
 import Clipboard from 'clipboard';
 import { MutableRefObject, useEffect, useRef } from 'react';
 
-import { LgtmImageUrl } from '../types/lgtmImage';
+import type { LgtmImageUrl } from '../types';
 
 type Request = {
   onCopySuccess: () => void;

--- a/src/hooks/useSwitchLanguage.ts
+++ b/src/hooks/useSwitchLanguage.ts
@@ -5,7 +5,7 @@ import {
   commonStateSelector,
   updateIsLanguageMenuDisplayed,
   updateLanguage,
-} from '../stores/valtio/common';
+} from '../stores';
 
 import type { ChangeLanguageCallback, Language } from '../types';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,18 @@
 export { useSwitchLanguage } from './hooks';
+
 export * from './templates';
-export * from './types';
+
+export type {
+  Language,
+  ChangeLanguageCallback,
+  LgtmImageUrl,
+  LgtmImage,
+  AcceptedTypesImageExtension,
+  ImageValidator,
+  ImageUploader,
+  CatImagesFetcher,
+} from './types';
+
 export {
   createSuccessResult,
   createFailureResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,14 @@
 export * from './hooks';
 export * from './templates';
 export * from './types';
-export * from './features';
+export {
+  createSuccessResult,
+  createFailureResult,
+  isSuccessResult,
+  isFailureResult,
+  errorType,
+  type Result,
+  SuccessResult,
+  FailureResult,
+  ErrorType,
+} from './features';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from './hooks';
+export { useSwitchLanguage } from './hooks';
 export * from './templates';
 export * from './types';
 export {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,10 @@
+export {
+  commonStateSelector,
+  updateLanguage,
+  updateIsLanguageMenuDisplayed,
+  lgtmImageStateSelector,
+  updateLgtmImages,
+  updateIsFailedFetchLgtmImages,
+  type CommonState,
+  LgtmImageState,
+} from './valtio';

--- a/src/stores/valtio/common.ts
+++ b/src/stores/valtio/common.ts
@@ -1,6 +1,6 @@
 import { proxy } from 'valtio';
 
-import type { Language } from '../../types/language';
+import type { Language } from '../../types';
 
 export type CommonState = {
   isLanguageMenuDisplayed: boolean;

--- a/src/stores/valtio/index.ts
+++ b/src/stores/valtio/index.ts
@@ -1,0 +1,12 @@
+export {
+  commonStateSelector,
+  updateLanguage,
+  updateIsLanguageMenuDisplayed,
+  type CommonState,
+} from './common';
+export {
+  lgtmImageStateSelector,
+  updateLgtmImages,
+  updateIsFailedFetchLgtmImages,
+  type LgtmImageState,
+} from './lgtmImage';

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,1 @@
+export { mixins } from './mixins';

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
@@ -1,6 +1,6 @@
 import { MarkdownContents } from '../../components/MarkdownContents';
 import { useSwitchLanguage } from '../../hooks';
-import { assertNever } from '../../utils/assertNever';
+import { assertNever } from '../../utils';
 
 import { TermsOrPrivacyTemplate, type TemplateType } from '.';
 

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
@@ -1,6 +1,6 @@
 import { MarkdownContents } from '../../components/MarkdownContents';
 import { useSwitchLanguage } from '../../hooks';
-import assertNever from '../../utils/assertNever';
+import { assertNever } from '../../utils/assertNever';
 
 import { TermsOrPrivacyTemplate, type TemplateType } from '.';
 

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 
 import { LibraryBooks } from '../../components/Icon/LibraryBooks';
 import { MarkdownPageTitle } from '../../components/MarkdownPageTitle';
-import { createLinksFromLanguages as createPrivacyPolicyLinksFromLanguages } from '../../features/privacyPolicy';
-import { createLinksFromLanguages as createTermsOfUseLinksFromLanguages } from '../../features/termsOfUse';
+import { createPrivacyPolicyLinksFromLanguages } from '../../features/privacyPolicy';
+import { createTermsOfUseLinksFromLanguages } from '../../features/termsOfUse';
 import { ResponsiveLayout } from '../../layouts';
 import { Language } from '../../types';
 import assertNever from '../../utils/assertNever';

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -1,13 +1,15 @@
 import styled from 'styled-components';
 
-import { LibraryBooks } from '../../components/Icon/LibraryBooks';
+import { LibraryBooks } from '../../components';
 import { MarkdownPageTitle } from '../../components/MarkdownPageTitle';
-import { createPrivacyPolicyLinksFromLanguages } from '../../features/privacyPolicy';
-import { createTermsOfUseLinksFromLanguages } from '../../features/termsOfUse';
+import {
+  createPrivacyPolicyLinksFromLanguages,
+  createTermsOfUseLinksFromLanguages,
+} from '../../features';
 import { ResponsiveLayout } from '../../layouts';
-import { Language } from '../../types';
-import { assertNever } from '../../utils/assertNever';
+import { assertNever } from '../../utils';
 
+import type { Language } from '../../types';
 import type { FC, MouseEventHandler, ReactNode } from 'react';
 
 export type TemplateType = 'terms' | 'privacy';

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -6,7 +6,7 @@ import { createPrivacyPolicyLinksFromLanguages } from '../../features/privacyPol
 import { createTermsOfUseLinksFromLanguages } from '../../features/termsOfUse';
 import { ResponsiveLayout } from '../../layouts';
 import { Language } from '../../types';
-import assertNever from '../../utils/assertNever';
+import { assertNever } from '../../utils/assertNever';
 
 import type { FC, MouseEventHandler, ReactNode } from 'react';
 

--- a/src/templates/TopTemplate/AppDescriptionArea.tsx
+++ b/src/templates/TopTemplate/AppDescriptionArea.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import assertNever from '../../utils/assertNever';
+import { assertNever } from '../../utils/assertNever';
 
 import type { Language } from '../../types/language';
 import type { FC } from 'react';

--- a/src/templates/TopTemplate/AppDescriptionArea.tsx
+++ b/src/templates/TopTemplate/AppDescriptionArea.tsx
@@ -1,8 +1,8 @@
 import styled, { css } from 'styled-components';
 
-import { assertNever } from '../../utils/assertNever';
+import { assertNever } from '../../utils';
 
-import type { Language } from '../../types/language';
+import type { Language } from '../../types';
 import type { FC } from 'react';
 
 const Wrapper = styled.div``;

--- a/src/templates/TopTemplate/TopTemplate.stories.tsx
+++ b/src/templates/TopTemplate/TopTemplate.stories.tsx
@@ -1,10 +1,10 @@
 import Image from 'next/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
-import { LgtmImage } from '../../types';
 
 import { TopTemplate } from './.';
 
+import type { LgtmImage } from '../../types';
 import type { ComponentStoryObj, Meta } from '@storybook/react';
 
 export default {

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -2,18 +2,20 @@ import styled from 'styled-components';
 import { useSnapshot } from 'valtio';
 
 import { ErrorContent, LgtmImages } from '../../components';
-import { CatButtonGroup } from '../../components/Button/CatButtonGroup';
-import { AppUrl } from '../../constants/url';
-import { errorType } from '../../features';
-import { NewArrivalCatImagesFetcherError } from '../../features/errors/NewArrivalCatImagesFetcherError';
-import { RandomCatImagesFetcherError } from '../../features/errors/RandomCatImagesFetcherError';
+import { CatButtonGroup } from '../../components/Button';
+import { AppUrl } from '../../constants';
+import {
+  errorType,
+  NewArrivalCatImagesFetcherError,
+  RandomCatImagesFetcherError,
+} from '../../features';
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
 import {
   lgtmImageStateSelector,
   updateIsFailedFetchLgtmImages,
   updateLgtmImages,
-} from '../../stores/valtio/lgtmImage';
+} from '../../stores';
 
 import { AppDescriptionArea } from './AppDescriptionArea';
 

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -2,13 +2,13 @@
 import Image from 'next/image';
 
 import { createSuccessResult } from '../../features';
-import { AcceptedTypesImageExtension } from '../../types';
-import { sleep } from '../../utils/sleep';
+import { sleep } from '../../utils';
 
 import cat from './images/cat.webp';
 
 import { UploadTemplate } from '.';
 
+import type { AcceptedTypesImageExtension } from '../../types';
 import type { ComponentStoryObj, Meta } from '@storybook/react';
 
 const CatImage = () => (

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { UploadForm } from '../../components';
-import { AppUrl } from '../../constants/url';
+import { AppUrl } from '../../constants';
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
 import {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export type { Language, ChangeLanguageCallback } from './language';
+
 export type {
   LgtmImageUrl,
   LgtmImage,
@@ -7,3 +8,7 @@ export type {
   ImageUploader,
   CatImagesFetcher,
 } from './lgtmImage';
+
+export { CustomDataAttrGtmClick } from './gtm';
+
+export { LinkAttribute } from './link';

--- a/src/types/lgtmImage.ts
+++ b/src/types/lgtmImage.ts
@@ -1,4 +1,4 @@
-import { SuccessResult } from '../features/result';
+import type { SuccessResult } from '../features';
 
 export type LgtmImageUrl = `https://${string}`;
 

--- a/src/utils/assertNever.ts
+++ b/src/utils/assertNever.ts
@@ -1,6 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const assertNever = (value: never): never => {
+export const assertNever = (value: never): never => {
   throw new Error('Unexpected value. Should have been never.');
 };
-
-export default assertNever;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,2 @@
+export { assertNever } from './assertNever';
+export { sleep } from './sleep';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/163

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/163 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

[optional] ただし UI 変更の時は [required]

# 変更点概要

- index.ts を使ってexportする形に統一
- export defaultの利用を辞めた

export defaultを辞める理由に関しては [こちら](https://github.com/nekochans/lgtm-cat-frontend/blob/main/src/README.md#export-default-%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6) に記載してある。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし