### PR TITLE
TopTemplateにCatRandomCopyButtonを追加

### DIFF
--- a/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.stories.tsx
+++ b/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.stories.tsx
@@ -9,12 +9,14 @@ export default {
 
 type Story = ComponentStoryObj<typeof CatRandomCopyButton>;
 
-const onClick = () =>
+const callback = () =>
   // eslint-disable-next-line no-console
   console.log('CatRandomCopyButton Clicked!');
 
 export const Default: Story = {
   args: {
-    onClick,
+    imageUrl:
+      'https://lgtm-images.lgtmeow.com/2022/09/14/11/151f27e7-f9fd-4093-8f87-cd95d9cdadb3.webp',
+    callback,
   },
 };

--- a/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
+++ b/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
@@ -1,9 +1,13 @@
 import { FaRandom } from 'react-icons/fa';
 import styled from 'styled-components';
 
+import { defaultAppUrl, type AppUrl } from '../../../constants';
+import { useClipboardMarkdown, useCopySuccess } from '../../../hooks';
 import { mixins } from '../../../styles';
+import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
 import slash from '../images/slash.png';
 
+import type { LgtmImageUrl } from '../../../types';
 import type { FC, ComponentProps } from 'react';
 
 const StyledButton = styled.button`
@@ -27,11 +31,32 @@ const faRandomStyle = {
   flexGrow: 0,
 };
 
-type Props = ComponentProps<'button'>;
+type Props = ComponentProps<'button'> & {
+  imageUrl: LgtmImageUrl;
+  callback?: () => void;
+  appUrl?: AppUrl;
+};
 
-export const CatRandomCopyButton: FC<Props> = ({ onClick }) => (
-  <StyledButton onClick={onClick}>
-    <FaRandom style={faRandomStyle} />
-    <Text>Cats Random Copied</Text>
-  </StyledButton>
-);
+export const CatRandomCopyButton: FC<Props> = ({
+  imageUrl,
+  callback,
+  appUrl,
+}) => {
+  const { copied, onCopySuccess } = useCopySuccess(callback);
+
+  const { imageContextRef } = useClipboardMarkdown({
+    onCopySuccess,
+    imageUrl,
+    appUrl: appUrl || defaultAppUrl,
+  });
+
+  return (
+    <>
+      <StyledButton ref={imageContextRef}>
+        <FaRandom style={faRandomStyle} />
+        <Text>Cats Random Copied</Text>
+      </StyledButton>
+      {copied ? <CopiedGithubMarkdownMessage /> : ''}
+    </>
+  );
+};

--- a/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
+++ b/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
@@ -56,7 +56,7 @@ export const CatRandomCopyButton: FC<Props> = ({
         <FaRandom style={faRandomStyle} />
         <Text>Cats Random Copied</Text>
       </StyledButton>
-      {copied ? <CopiedGithubMarkdownMessage /> : ''}
+      {copied ? <CopiedGithubMarkdownMessage position="upper" /> : ''}
     </>
   );
 };

--- a/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
+++ b/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
@@ -31,7 +31,7 @@ const faRandomStyle = {
   flexGrow: 0,
 };
 
-type Props = ComponentProps<'button'> & {
+export type Props = ComponentProps<'button'> & {
   imageUrl: LgtmImageUrl;
   callback?: () => void;
   appUrl?: AppUrl;

--- a/src/components/Button/CatRandomCopyButton/index.ts
+++ b/src/components/Button/CatRandomCopyButton/index.ts
@@ -1,1 +1,4 @@
-export { CatRandomCopyButton } from './CatRandomCopyButton';
+export {
+  CatRandomCopyButton,
+  type Props as CatRandomCopyButtonProps,
+} from './CatRandomCopyButton';

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,3 +1,6 @@
-export { CatRandomCopyButton } from './CatRandomCopyButton';
+export {
+  CatRandomCopyButton,
+  type CatRandomCopyButtonProps,
+} from './CatRandomCopyButton';
 export { UploadCatButton } from './UploadCatButton';
 export { CatButtonGroup } from './CatButtonGroup';

--- a/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
+++ b/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
@@ -1,10 +1,9 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import type { FC } from 'react';
 
-const Wrapper = styled.div`
+const baseCss = css`
   position: absolute;
-  bottom: 30%;
   left: 50%;
   padding: 3%;
   color: #fff;
@@ -14,6 +13,33 @@ const Wrapper = styled.div`
   transform: translate(-50%, 0);
 `;
 
-export const CopiedGithubMarkdownMessage: FC = () => (
-  <Wrapper>Github Markdown Copied!</Wrapper>
-);
+const DefaultWrapper = styled.div`
+  ${baseCss};
+  bottom: 30%;
+`;
+
+const UpperWrapper = styled.div`
+  ${baseCss};
+  top: 30%;
+  opacity: 0.5;
+`;
+
+type Props = {
+  position?: 'default' | 'upper';
+};
+
+export const CopiedGithubMarkdownMessage: FC<Props> = ({
+  position = 'default',
+}) => {
+  const text = 'Github Markdown Copied!';
+
+  return (
+    <>
+      {position === 'default' ? (
+        <DefaultWrapper>{text}</DefaultWrapper>
+      ) : (
+        <UpperWrapper>{text}</UpperWrapper>
+      )}
+    </>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,6 @@ export { Footer } from './Footer';
 export { Header } from './Header';
 export { LgtmImages } from './LgtmImages';
 export { UploadForm } from './Upload/UploadForm';
-export { CatRandomCopyButton } from './Button';
+export { CatRandomCopyButton, CatRandomCopyButtonProps } from './Button';
 export { ErrorContent, ErrorContentProps } from './ErrorContent';
 export { LibraryBooks } from './Icon/LibraryBooks';

--- a/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
+++ b/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+import {
+  CatRandomCopyButton,
+  type CatRandomCopyButtonProps,
+} from '../../components';
+
+import type { FC } from 'react';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+`;
+
+type Props = CatRandomCopyButtonProps;
+
+export const CatRandomCopyButtonWrapper: FC<Props> = ({
+  appUrl,
+  imageUrl,
+  callback,
+}) => (
+  <Wrapper>
+    <CatRandomCopyButton
+      appUrl={appUrl}
+      imageUrl={imageUrl}
+      callback={callback}
+    />
+  </Wrapper>
+);

--- a/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
+++ b/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
@@ -8,7 +8,8 @@ import {
 import type { FC } from 'react';
 
 const Wrapper = styled.div`
-  display: grid;
+  display: flex;
+  flex-direction: row;
   gap: 20px;
   align-items: center;
   justify-content: center;

--- a/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
+++ b/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
@@ -8,8 +8,7 @@ import {
 import type { FC } from 'react';
 
 const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
+  display: grid;
   gap: 20px;
   align-items: center;
   justify-content: center;

--- a/src/templates/TopTemplate/TopTemplate.stories.tsx
+++ b/src/templates/TopTemplate/TopTemplate.stories.tsx
@@ -182,6 +182,10 @@ const fetchNewArrivalCatImagesCallback = () =>
   // eslint-disable-next-line no-console
   console.log('fetchNewArrivalCatImagesCallback executed!');
 
+const catRandomCopyCallback = () =>
+  // eslint-disable-next-line no-console
+  console.log('catRandomCopyCallback executed!');
+
 const changeLanguageCallback = () =>
   // eslint-disable-next-line no-console
   console.log('changeLanguageCallback executed!');
@@ -217,6 +221,7 @@ export const ViewInJapanese: Story = {
     clipboardMarkdownCallback,
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
+    catRandomCopyCallback,
     changeLanguageCallback,
   },
 };
@@ -232,6 +237,7 @@ export const ViewInEnglish: Story = {
     clipboardMarkdownCallback,
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
+    catRandomCopyCallback,
     changeLanguageCallback,
   },
 };
@@ -247,6 +253,7 @@ export const ViewInJapaneseError: Story = {
     clipboardMarkdownCallback,
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
+    catRandomCopyCallback,
     changeLanguageCallback,
   },
 };
@@ -262,6 +269,7 @@ export const ViewInEnglishError: Story = {
     clipboardMarkdownCallback,
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
+    catRandomCopyCallback,
     changeLanguageCallback,
   },
 };

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -1,11 +1,7 @@
 import styled from 'styled-components';
 import { useSnapshot } from 'valtio';
 
-import {
-  CatRandomCopyButton,
-  ErrorContent,
-  LgtmImages,
-} from '../../components';
+import { ErrorContent, LgtmImages } from '../../components';
 import { CatButtonGroup } from '../../components/Button';
 import { AppUrl } from '../../constants';
 import {
@@ -22,6 +18,7 @@ import {
 } from '../../stores';
 
 import { AppDescriptionArea } from './AppDescriptionArea';
+import { CatRandomCopyButtonWrapper } from './CatRandomCopyButtonWrapper';
 
 import type {
   Language,
@@ -36,15 +33,6 @@ const Wrapper = styled.div`
   grid-template-rows: auto 1fr auto;
   grid-template-columns: 100%;
   gap: 32px;
-`;
-
-const CatRandomCopyButtonWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 20px;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
 `;
 
 type Props = {
@@ -132,6 +120,11 @@ export const TopTemplate: FC<Props> = ({
 
   const { isFailedFetchLgtmImages } = snap;
 
+  const { imageUrl } =
+    fetchedLgtmImagesList[
+      Math.floor(Math.random() * fetchedLgtmImagesList.length)
+    ];
+
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">
       <ResponsiveLayout
@@ -143,17 +136,11 @@ export const TopTemplate: FC<Props> = ({
       >
         <Wrapper>
           <AppDescriptionArea language={selectedLanguage} />
-          <CatRandomCopyButtonWrapper>
-            <CatRandomCopyButton
-              appUrl={appUrl}
-              imageUrl={
-                fetchedLgtmImagesList[
-                  Math.floor(Math.random() * fetchedLgtmImagesList.length)
-                ].imageUrl
-              }
-              callback={catRandomCopyCallback}
-            />
-          </CatRandomCopyButtonWrapper>
+          <CatRandomCopyButtonWrapper
+            appUrl={appUrl}
+            imageUrl={imageUrl}
+            callback={catRandomCopyCallback}
+          />
           <CatButtonGroup
             onClickFetchRandomCatButton={onClickFetchRandomCatButton}
             onClickFetchNewArrivalCatButton={onClickFetchNewArrivalCatButton}

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -1,7 +1,11 @@
 import styled from 'styled-components';
 import { useSnapshot } from 'valtio';
 
-import { ErrorContent, LgtmImages } from '../../components';
+import {
+  CatRandomCopyButton,
+  ErrorContent,
+  LgtmImages,
+} from '../../components';
 import { CatButtonGroup } from '../../components/Button';
 import { AppUrl } from '../../constants';
 import {
@@ -34,6 +38,15 @@ const Wrapper = styled.div`
   gap: 32px;
 `;
 
+const CatRandomCopyButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+`;
+
 type Props = {
   language: Language;
   lgtmImages: LgtmImage[];
@@ -44,6 +57,7 @@ type Props = {
   clipboardMarkdownCallback?: () => void;
   fetchRandomCatImagesCallback?: () => void;
   fetchNewArrivalCatImagesCallback?: () => void;
+  catRandomCopyCallback?: () => void;
   changeLanguageCallback?: ChangeLanguageCallback;
 };
 
@@ -58,6 +72,7 @@ export const TopTemplate: FC<Props> = ({
   clipboardMarkdownCallback,
   fetchRandomCatImagesCallback,
   fetchNewArrivalCatImagesCallback,
+  catRandomCopyCallback,
   changeLanguageCallback,
 }) => {
   const {
@@ -128,6 +143,17 @@ export const TopTemplate: FC<Props> = ({
       >
         <Wrapper>
           <AppDescriptionArea language={selectedLanguage} />
+          <CatRandomCopyButtonWrapper>
+            <CatRandomCopyButton
+              appUrl={appUrl}
+              imageUrl={
+                fetchedLgtmImagesList[
+                  Math.floor(Math.random() * fetchedLgtmImagesList.length)
+                ].imageUrl
+              }
+              callback={catRandomCopyCallback}
+            />
+          </CatRandomCopyButtonWrapper>
           <CatButtonGroup
             onClickFetchRandomCatButton={onClickFetchRandomCatButton}
             onClickFetchNewArrivalCatButton={onClickFetchNewArrivalCatButton}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/187

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/187 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-lvwgilcvtj.chromatic.com/?path=/story/src-templates-toptemplate-toptemplate-tsx--view-in-japanese&globals=backgrounds.grid:true

# 変更点概要

トップに `CatRandomCopyButton` を追加してクリック時にRandomでMarkdownSourceをコピーするように変更。

`CatRandomCopyButton` 既に取得済のLGTM画像URLのどれかをRandomで選んでいるだけなので、画面上に表示されているどれかの🐱画像がコピーされるようになっている。

# レビュアーに重点的にチェックして欲しい点

`CatRandomCopyButton` 押下時の仕様が問題ないか確認してもらえると:pray:

`CatRandomCopyButton` 押下時にねこ画像取得関数をコールしてその中からRandomで選ぶという選択もあったけど、APIの呼び出し回数が増える原因を作ってしまうから今の仕様にした:cat2:

# 補足情報

特になし
