### PR TITLE
言語切替メニューの仕様変更

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -76,8 +76,7 @@ export const Header: FC<Props> = ({
   language,
   isLanguageMenuDisplayed,
   onClickLanguageButton,
-  onClickEn,
-  onClickJa,
+  currentUrlPath,
 }) => {
   const [isMenuOpened, setIsMenuOpened] = useState<boolean>(false);
 
@@ -107,11 +106,7 @@ export const Header: FC<Props> = ({
           </Link>
           <LanguageButton onClick={onClickLanguageButton} />
           {isLanguageMenuDisplayed ? (
-            <LanguageMenu
-              language={language}
-              onClickEn={onClickEn}
-              onClickJa={onClickJa}
-            />
+            <LanguageMenu language={language} currentUrlPath={currentUrlPath} />
           ) : (
             ''
           )}

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -1,8 +1,8 @@
-import type { FC, MouseEvent } from 'react';
+import type { FC } from 'react';
+import Link from 'next/link';
 import { FaAngleRight } from 'react-icons/fa';
 import styled, { css } from 'styled-components';
-
-import { Language } from '../../types';
+import type { Language } from '../../types';
 
 const textWrapperStyle = css`
   display: flex;
@@ -17,7 +17,7 @@ const textWrapperStyle = css`
   background: rgba(54, 46, 43, 0.4);
 `;
 
-const StyledLanguageMenu = styled.div`
+const StyledLanguageMenu = styled.ul`
   @media (max-width: 767px) {
     right: 0;
   }
@@ -30,7 +30,12 @@ const StyledLanguageMenu = styled.div`
   padding: 0;
 `;
 
-const EnTextWrapper = styled.button`
+const StyledLink = styled.a`
+  text-decoration: none;
+  cursor: pointer;
+`;
+
+const EnTextWrapper = styled.li`
   ${textWrapperStyle};
   order: 0;
 `;
@@ -51,7 +56,7 @@ const EnText = styled.div`
   cursor: pointer;
 `;
 
-const Separator = styled.div`
+const Separator = styled.li`
   flex: none;
   flex-grow: 0;
   order: 1;
@@ -60,7 +65,7 @@ const Separator = styled.div`
   border: 1px solid rgba(54, 46, 43, 0.5);
 `;
 
-const JaTextWrapper = styled.button`
+const JaTextWrapper = styled.li`
   ${textWrapperStyle};
   order: 2;
 `;
@@ -83,24 +88,31 @@ const JaText = styled.div`
 
 export type Props = {
   language: Language;
-  onClickEn: (event: MouseEvent<HTMLButtonElement>) => void;
-  onClickJa: (event: MouseEvent<HTMLButtonElement>) => void;
+  currentUrlPath: string;
 };
 
-export const LanguageMenu: FC<Props> = ({ language, onClickEn, onClickJa }) => (
-  <StyledLanguageMenu>
-    <EnTextWrapper onClick={onClickEn}>
-      <EnText>
-        {language === 'en' ? <FaAngleRight /> : ''}
-        English
-      </EnText>
-    </EnTextWrapper>
-    <Separator />
-    <JaTextWrapper onClick={onClickJa}>
-      <JaText>
-        {language === 'ja' ? <FaAngleRight /> : ''}
-        日本語
-      </JaText>
-    </JaTextWrapper>
+export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
+  <StyledLanguageMenu role="menu">
+    <Link href={currentUrlPath} locale="en" prefetch={false}>
+      <StyledLink role="presentation" data-gtm-click="language-menu-en-link">
+        <EnTextWrapper role="menuitem">
+          <EnText>
+            {language === 'en' ? <FaAngleRight /> : ''}
+            English
+          </EnText>
+        </EnTextWrapper>
+      </StyledLink>
+    </Link>
+    <Separator role="presentation" />
+    <Link href={currentUrlPath} locale="ja" prefetch={false}>
+      <StyledLink role="presentation" data-gtm-click="language-menu-ja-link">
+        <JaTextWrapper role="menuitem">
+          <JaText>
+            {language === 'ja' ? <FaAngleRight /> : ''}
+            日本語
+          </JaText>
+        </JaTextWrapper>
+      </StyledLink>
+    </Link>
   </StyledLanguageMenu>
 );

--- a/src/hooks/useSwitchLanguage.ts
+++ b/src/hooks/useSwitchLanguage.ts
@@ -1,58 +1,18 @@
 import type { MouseEvent, MouseEventHandler } from 'react';
 import { useSnapshot } from 'valtio';
 
-import {
-  commonStateSelector,
-  updateIsLanguageMenuDisplayed,
-  updateLanguage,
-} from '../stores';
-
-import type { ChangeLanguageCallback, Language } from '../types';
-
-const languageEn = 'en';
-
-const languageJa = 'ja';
+import { commonStateSelector, updateIsLanguageMenuDisplayed } from '../stores';
 
 type UseSwitchLanguageResponse = {
   isLanguageMenuDisplayed: boolean;
-  selectedLanguage: Language;
-  onClickEn: MouseEventHandler<HTMLButtonElement>;
-  onClickJa: MouseEventHandler<HTMLButtonElement>;
   onClickLanguageButton: MouseEventHandler<HTMLDivElement>;
   onClickOutSideMenu: MouseEventHandler<HTMLDivElement>;
 };
 
-export const useSwitchLanguage = (
-  language: Language,
-  changeLanguageCallback?: ChangeLanguageCallback
-): UseSwitchLanguageResponse => {
+export const useSwitchLanguage = (): UseSwitchLanguageResponse => {
   const snap = useSnapshot(commonStateSelector());
 
   const { isLanguageMenuDisplayed } = snap;
-
-  const selectedLanguage = snap.language ? snap.language : language;
-
-  const onClickEn: MouseEventHandler<HTMLButtonElement> = (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    event: MouseEvent<HTMLButtonElement>
-  ) => {
-    updateLanguage(languageEn);
-
-    if (changeLanguageCallback) {
-      changeLanguageCallback(languageEn);
-    }
-  };
-
-  const onClickJa: MouseEventHandler<HTMLButtonElement> = (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    event: MouseEvent<HTMLButtonElement>
-  ) => {
-    updateLanguage(languageJa);
-
-    if (changeLanguageCallback) {
-      changeLanguageCallback(languageJa);
-    }
-  };
 
   const onClickLanguageButton: MouseEventHandler<HTMLDivElement> = (
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -73,9 +33,6 @@ export const useSwitchLanguage = (
 
   return {
     isLanguageMenuDisplayed,
-    selectedLanguage,
-    onClickEn,
-    onClickJa,
     onClickLanguageButton,
     onClickOutSideMenu,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ export * from './templates';
 
 export type {
   Language,
-  ChangeLanguageCallback,
   LgtmImageUrl,
   LgtmImage,
   AcceptedTypesImageExtension,

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
@@ -25,8 +25,7 @@ export const ResponsiveLayout: FC<Props> = ({
   language,
   isLanguageMenuDisplayed,
   onClickLanguageButton,
-  onClickEn,
-  onClickJa,
+  currentUrlPath,
   children,
 }) => (
   <Wrapper>
@@ -34,8 +33,7 @@ export const ResponsiveLayout: FC<Props> = ({
       language={language}
       isLanguageMenuDisplayed={isLanguageMenuDisplayed}
       onClickLanguageButton={onClickLanguageButton}
-      onClickEn={onClickEn}
-      onClickJa={onClickJa}
+      currentUrlPath={currentUrlPath}
     />
     <ContentsWrapper>{children}</ContentsWrapper>
     <Footer language={language} />

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,6 +1,5 @@
 export {
   commonStateSelector,
-  updateLanguage,
   updateIsLanguageMenuDisplayed,
   lgtmImageStateSelector,
   updateLgtmImages,

--- a/src/stores/valtio/common.ts
+++ b/src/stores/valtio/common.ts
@@ -17,8 +17,4 @@ export const updateIsLanguageMenuDisplayed = (
   commonState.isLanguageMenuDisplayed = isLanguageMenuDisplayed;
 };
 
-export const updateLanguage = (language: Language): void => {
-  commonState.language = language;
-};
-
 export const commonStateSelector = (): CommonState => commonState;

--- a/src/stores/valtio/index.ts
+++ b/src/stores/valtio/index.ts
@@ -1,6 +1,5 @@
 export {
   commonStateSelector,
-  updateLanguage,
   updateIsLanguageMenuDisplayed,
   type CommonState,
 } from './common';

--- a/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
@@ -55,16 +55,12 @@ const ServiceUnavailableImage = () => (
   />
 );
 
-const changeLanguageCallback: () => void = () =>
-  // eslint-disable-next-line no-console
-  console.log('changeLanguageCallback executed!');
-
 export const NotFoundViewInJapanese: Story = {
   args: {
     type: 404,
     language: 'ja',
     catImage: <NotFoundImage />,
-    changeLanguageCallback,
+    currentUrlPath: '/404',
   },
 };
 
@@ -73,7 +69,7 @@ export const NotFoundViewInEnglish: Story = {
     type: 404,
     language: 'en',
     catImage: <NotFoundImage />,
-    changeLanguageCallback,
+    currentUrlPath: '/404',
   },
 };
 
@@ -82,7 +78,7 @@ export const InternalServerErrorViewInJapanese: Story = {
     type: 500,
     language: 'ja',
     catImage: <InternalServerErrorImage />,
-    changeLanguageCallback,
+    currentUrlPath: '/500',
   },
 };
 
@@ -91,7 +87,7 @@ export const InternalServerErrorViewInEnglish: Story = {
     type: 500,
     language: 'en',
     catImage: <InternalServerErrorImage />,
-    changeLanguageCallback,
+    currentUrlPath: '/500',
   },
 };
 
@@ -100,7 +96,7 @@ export const ServiceUnavailableViewInJapanese: Story = {
     type: 503,
     language: 'ja',
     catImage: <ServiceUnavailableImage />,
-    changeLanguageCallback,
+    currentUrlPath: '/503',
   },
 };
 
@@ -109,6 +105,6 @@ export const ServiceUnavailableViewInEnglish: Story = {
     type: 503,
     language: 'en',
     catImage: <ServiceUnavailableImage />,
-    changeLanguageCallback,
+    currentUrlPath: '/503',
   },
 };

--- a/src/templates/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.tsx
@@ -3,39 +3,30 @@ import { ErrorContent, type ErrorContentProps } from '../../components';
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
 
-import type { ChangeLanguageCallback } from '../../types';
-
 type Props = ErrorContentProps & {
-  changeLanguageCallback?: ChangeLanguageCallback;
+  currentUrlPath: string;
 };
 
 export const ErrorTemplate: FC<Props> = ({
   type,
   language,
   catImage,
-  changeLanguageCallback,
+  currentUrlPath,
 }) => {
-  const {
-    isLanguageMenuDisplayed,
-    selectedLanguage,
-    onClickEn,
-    onClickJa,
-    onClickLanguageButton,
-    onClickOutSideMenu,
-  } = useSwitchLanguage(language, changeLanguageCallback);
+  const { isLanguageMenuDisplayed, onClickLanguageButton, onClickOutSideMenu } =
+    useSwitchLanguage();
 
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">
       <ResponsiveLayout
-        language={selectedLanguage}
-        onClickJa={onClickJa}
-        onClickEn={onClickEn}
+        language={language}
         isLanguageMenuDisplayed={isLanguageMenuDisplayed}
         onClickLanguageButton={onClickLanguageButton}
+        currentUrlPath={currentUrlPath}
       >
         <ErrorContent
           type={type}
-          language={selectedLanguage}
+          language={language}
           catImage={catImage}
           shouldDisplayBackToTopButton={true}
         />

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
@@ -228,30 +228,18 @@ type Props = {
 };
 
 const EnhanceTermsOrPrivacyTemplate: FC<Props> = ({ type, language }) => {
-  const changeLanguageCallback = () =>
-    // eslint-disable-next-line no-console
-    console.log('changeLanguageCallback executed!');
-
-  const {
-    isLanguageMenuDisplayed,
-    selectedLanguage,
-    onClickEn,
-    onClickJa,
-    onClickLanguageButton,
-    onClickOutSideMenu,
-  } = useSwitchLanguage(language, changeLanguageCallback);
+  const { isLanguageMenuDisplayed, onClickLanguageButton, onClickOutSideMenu } =
+    useSwitchLanguage();
 
   return (
     <TermsOrPrivacyTemplate
       type={type}
-      language={selectedLanguage}
+      language={language}
       isLanguageMenuDisplayed={isLanguageMenuDisplayed}
-      onClickEn={onClickEn}
-      onClickJa={onClickJa}
       onClickLanguageButton={onClickLanguageButton}
       onClickOutSideMenu={onClickOutSideMenu}
     >
-      <MarkdownContents markdown={getMarkdownSource(type, selectedLanguage)} />
+      <MarkdownContents markdown={getMarkdownSource(type, language)} />
     </TermsOrPrivacyTemplate>
   );
 };

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -53,8 +53,6 @@ type Props = {
   type: TemplateType;
   language: Language;
   isLanguageMenuDisplayed: boolean;
-  onClickEn: MouseEventHandler;
-  onClickJa: MouseEventHandler;
   onClickLanguageButton: MouseEventHandler;
   onClickOutSideMenu: MouseEventHandler;
   children: ReactNode;
@@ -64,25 +62,29 @@ export const TermsOrPrivacyTemplate: FC<Props> = ({
   type,
   language,
   isLanguageMenuDisplayed,
-  onClickEn,
-  onClickJa,
   onClickLanguageButton,
   onClickOutSideMenu,
   children,
-}) => (
-  <div onClick={onClickOutSideMenu} aria-hidden="true">
-    <ResponsiveLayout
-      language={language}
-      onClickJa={onClickJa}
-      onClickEn={onClickEn}
-      isLanguageMenuDisplayed={isLanguageMenuDisplayed}
-      onClickLanguageButton={onClickLanguageButton}
-    >
-      <Wrapper>
-        <MarkdownPageTitle text={createTitle(type, language)} />
-        <LibraryBooks />
-        <ChildrenWrapper>{children}</ChildrenWrapper>
-      </Wrapper>
-    </ResponsiveLayout>
-  </div>
-);
+}) => {
+  const currentUrlPath =
+    type === 'terms'
+      ? createTermsOfUseLinksFromLanguages(language).link
+      : createPrivacyPolicyLinksFromLanguages(language).link;
+
+  return (
+    <div onClick={onClickOutSideMenu} aria-hidden="true">
+      <ResponsiveLayout
+        language={language}
+        isLanguageMenuDisplayed={isLanguageMenuDisplayed}
+        onClickLanguageButton={onClickLanguageButton}
+        currentUrlPath={currentUrlPath}
+      >
+        <Wrapper>
+          <MarkdownPageTitle text={createTitle(type, language)} />
+          <LibraryBooks />
+          <ChildrenWrapper>{children}</ChildrenWrapper>
+        </Wrapper>
+      </ResponsiveLayout>
+    </div>
+  );
+};

--- a/src/templates/TopTemplate/TopTemplate.stories.tsx
+++ b/src/templates/TopTemplate/TopTemplate.stories.tsx
@@ -185,10 +185,6 @@ const catRandomCopyCallback: () => void = () =>
   // eslint-disable-next-line no-console
   console.log('catRandomCopyCallback executed!');
 
-const changeLanguageCallback: () => void = () =>
-  // eslint-disable-next-line no-console
-  console.log('changeLanguageCallback executed!');
-
 // eslint-disable-next-line @typescript-eslint/require-await
 const failureRandomCatImagesFetcher: CatImagesFetcher = async () => {
   throw new Error('failureRandomCatImagesFetcher');
@@ -222,7 +218,6 @@ export const ViewInJapanese: Story = {
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
     catRandomCopyCallback,
-    changeLanguageCallback,
   },
 };
 
@@ -238,7 +233,6 @@ export const ViewInEnglish: Story = {
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
     catRandomCopyCallback,
-    changeLanguageCallback,
   },
 };
 
@@ -254,7 +248,6 @@ export const ViewInJapaneseError: Story = {
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
     catRandomCopyCallback,
-    changeLanguageCallback,
   },
 };
 
@@ -270,6 +263,5 @@ export const ViewInEnglishError: Story = {
     fetchRandomCatImagesCallback,
     fetchNewArrivalCatImagesCallback,
     catRandomCopyCallback,
-    changeLanguageCallback,
   },
 };

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -18,12 +18,7 @@ import {
   updateLgtmImages,
 } from '../../stores';
 
-import type {
-  Language,
-  ChangeLanguageCallback,
-  CatImagesFetcher,
-  LgtmImage,
-} from '../../types';
+import type { Language, CatImagesFetcher, LgtmImage } from '../../types';
 import { AppDescriptionArea } from './AppDescriptionArea';
 import { CatRandomCopyButtonWrapper } from './CatRandomCopyButtonWrapper';
 
@@ -45,7 +40,6 @@ type Props = {
   fetchRandomCatImagesCallback?: () => void;
   fetchNewArrivalCatImagesCallback?: () => void;
   catRandomCopyCallback?: () => void;
-  changeLanguageCallback?: ChangeLanguageCallback;
 };
 
 // eslint-disable-next-line max-lines-per-function
@@ -60,16 +54,9 @@ export const TopTemplate: FC<Props> = ({
   fetchRandomCatImagesCallback,
   fetchNewArrivalCatImagesCallback,
   catRandomCopyCallback,
-  changeLanguageCallback,
 }) => {
-  const {
-    isLanguageMenuDisplayed,
-    selectedLanguage,
-    onClickEn,
-    onClickJa,
-    onClickLanguageButton,
-    onClickOutSideMenu,
-  } = useSwitchLanguage(language, changeLanguageCallback);
+  const { isLanguageMenuDisplayed, onClickLanguageButton, onClickOutSideMenu } =
+    useSwitchLanguage();
 
   const snap = useSnapshot(lgtmImageStateSelector());
 
@@ -127,14 +114,13 @@ export const TopTemplate: FC<Props> = ({
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">
       <ResponsiveLayout
-        language={selectedLanguage}
-        onClickJa={onClickJa}
-        onClickEn={onClickEn}
+        language={language}
         isLanguageMenuDisplayed={isLanguageMenuDisplayed}
         onClickLanguageButton={onClickLanguageButton}
+        currentUrlPath="/"
       >
         <Wrapper>
-          <AppDescriptionArea language={selectedLanguage} />
+          <AppDescriptionArea language={language} />
           <CatRandomCopyButtonWrapper
             appUrl={appUrl}
             imageUrl={imageUrl}
@@ -147,7 +133,7 @@ export const TopTemplate: FC<Props> = ({
           {isFailedFetchLgtmImages === true ? (
             <ErrorContent
               type={errorType.internalServerError}
-              language={selectedLanguage}
+              language={language}
               catImage={errorCatImage}
               shouldDisplayBackToTopButton={false}
             />

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -44,10 +44,6 @@ const imageUploader: ImageUploader = async (
   });
 };
 
-const changeLanguageCallback: () => void = () =>
-  // eslint-disable-next-line no-console
-  console.log('changeLanguageCallback executed!');
-
 // eslint-disable-next-line no-console
 const uploadCallback: () => void = () =>
   console.log('uploadCallback executed!');
@@ -74,7 +70,6 @@ export const ViewInJapanese: Story = {
     imageValidator,
     imageUploader,
     catImage: <CatImage />,
-    changeLanguageCallback,
     uploadCallback,
     onClickCreatedLgtmImage,
     onClickMarkdownSourceCopyButton,
@@ -88,7 +83,6 @@ export const ViewInEnglish: Story = {
     imageValidator,
     imageUploader,
     catImage: <CatImage />,
-    changeLanguageCallback,
     uploadCallback,
     onClickCreatedLgtmImage,
     onClickMarkdownSourceCopyButton,

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -5,12 +5,7 @@ import { UploadForm } from '../../components';
 import { AppUrl } from '../../constants';
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
-import {
-  ChangeLanguageCallback,
-  Language,
-  ImageUploader,
-  ImageValidator,
-} from '../../types';
+import type { Language, ImageUploader, ImageValidator } from '../../types';
 
 const ImageWrapper = styled.div`
   display: grid;
@@ -26,7 +21,6 @@ type Props = {
   imageValidator: ImageValidator;
   imageUploader: ImageUploader;
   catImage: ReactNode;
-  changeLanguageCallback?: ChangeLanguageCallback;
   uploadCallback?: () => void;
   onClickCreatedLgtmImage?: () => void;
   onClickMarkdownSourceCopyButton?: () => void;
@@ -38,32 +32,24 @@ export const UploadTemplate: FC<Props> = ({
   imageValidator,
   imageUploader,
   catImage,
-  changeLanguageCallback,
   uploadCallback,
   onClickCreatedLgtmImage,
   onClickMarkdownSourceCopyButton,
   appUrl,
 }) => {
-  const {
-    isLanguageMenuDisplayed,
-    selectedLanguage,
-    onClickEn,
-    onClickJa,
-    onClickLanguageButton,
-    onClickOutSideMenu,
-  } = useSwitchLanguage(language, changeLanguageCallback);
+  const { isLanguageMenuDisplayed, onClickLanguageButton, onClickOutSideMenu } =
+    useSwitchLanguage();
 
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">
       <ResponsiveLayout
-        language={selectedLanguage}
-        onClickJa={onClickJa}
-        onClickEn={onClickEn}
+        language={language}
         isLanguageMenuDisplayed={isLanguageMenuDisplayed}
         onClickLanguageButton={onClickLanguageButton}
+        currentUrlPath="/upload"
       >
         <UploadForm
-          language={selectedLanguage}
+          language={language}
           imageValidator={imageValidator}
           imageUploader={imageUploader}
           uploadCallback={uploadCallback}

--- a/src/types/gtm.ts
+++ b/src/types/gtm.ts
@@ -6,4 +6,6 @@ export type CustomDataAttrGtmClick =
   | 'global-menu-top-link'
   | 'global-menu-upload-cat-link'
   | 'global-menu-terms-link'
-  | 'global-menu-privacy-link';
+  | 'global-menu-privacy-link'
+  | 'language-menu-en-link'
+  | 'language-menu-ja-link';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { Language, ChangeLanguageCallback } from './language';
+export type { Language } from './language';
 
 export type {
   LgtmImageUrl,

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,3 +1,1 @@
 export type Language = 'ja' | 'en';
-
-export type ChangeLanguageCallback = (language: Language) => void;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/191

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/191 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-jrxqrgiesi.chromatic.com/?path=/story/templates-toptemplate--view-in-japanese

# 変更点概要

言語メニューの仕様変更を実施、詳細は下記の通り

- 言語メニュー内のリンクをクリックすると対象言語へのリンク先に遷移するように変更
- 選択中の言語はState内持つ必要がなくなったので削除
- 言語変更時はカスタム属性でGTM上でイベントを検知出来るようになったのでコールバック関数は削除

Storybook上で言語切替の動作を再現出来なくなったが元々言語毎にStoryを作っていたので表示の確認は問題なし。

# レビュアーに重点的にチェックして欲しい点

仕様に関して問題ないか確認してもらえると:pray:

※ https://zenn.dev/steelydylan/articles/nextjs-with-i18n#%E8%A8%80%E8%AA%9E%E5%88%87%E3%82%8A%E6%9B%BF%E3%81%88 に載っている言語メニューの仕様と同じ

# 補足情報

破壊的な変更なのでPackageはメジャーアップデートとする。