### PR TITLE
言語切替メニューの表示崩れを修正

### DIFF
--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -10,11 +10,31 @@ type Story = ComponentStoryObj<typeof Header>;
 export const LanguageJa: Story = {
   args: {
     language: 'ja',
+    currentUrlPath: '/',
+    isLanguageMenuDisplayed: false,
+  },
+};
+
+export const LanguageJaMenuIsOpen: Story = {
+  args: {
+    language: 'ja',
+    currentUrlPath: '/',
+    isLanguageMenuDisplayed: true,
   },
 };
 
 export const LanguageEn: Story = {
   args: {
     language: 'en',
+    currentUrlPath: '/',
+    isLanguageMenuDisplayed: false,
+  },
+};
+
+export const LanguageEnMenuIsOpen: Story = {
+  args: {
+    language: 'en',
+    currentUrlPath: '/',
+    isLanguageMenuDisplayed: true,
   },
 };

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -17,7 +17,7 @@ const textWrapperStyle = css`
   background: rgba(54, 46, 43, 0.4);
 `;
 
-const StyledLanguageMenu = styled.ul`
+const StyledLanguageMenu = styled.nav`
   @media (max-width: 767px) {
     right: 0;
   }
@@ -30,17 +30,12 @@ const StyledLanguageMenu = styled.ul`
   padding: 0;
 `;
 
-const StyledLink = styled.a`
-  text-decoration: none;
-  cursor: pointer;
-`;
-
-const EnTextWrapper = styled.li`
+const EnTextWrapper = styled.span`
   ${textWrapperStyle};
   order: 0;
 `;
 
-const EnText = styled.div`
+const EnText = styled.a`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -56,7 +51,7 @@ const EnText = styled.div`
   cursor: pointer;
 `;
 
-const Separator = styled.li`
+const Separator = styled.span`
   flex: none;
   flex-grow: 0;
   order: 1;
@@ -65,12 +60,12 @@ const Separator = styled.li`
   border: 1px solid rgba(54, 46, 43, 0.5);
 `;
 
-const JaTextWrapper = styled.li`
+const JaTextWrapper = styled.span`
   ${textWrapperStyle};
   order: 2;
 `;
 
-const JaText = styled.div`
+const JaText = styled.a`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -92,27 +87,27 @@ export type Props = {
 };
 
 export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
-  <StyledLanguageMenu role="menu">
-    <Link href={currentUrlPath} locale="en" prefetch={false}>
-      <StyledLink role="presentation" data-gtm-click="language-menu-en-link">
-        <EnTextWrapper role="menuitem">
-          <EnText>
-            {language === 'en' ? <FaAngleRight /> : ''}
-            English
-          </EnText>
-        </EnTextWrapper>
-      </StyledLink>
-    </Link>
-    <Separator role="presentation" />
-    <Link href={currentUrlPath} locale="ja" prefetch={false}>
-      <StyledLink role="presentation" data-gtm-click="language-menu-ja-link">
-        <JaTextWrapper role="menuitem">
-          <JaText>
-            {language === 'ja' ? <FaAngleRight /> : ''}
-            日本語
-          </JaText>
-        </JaTextWrapper>
-      </StyledLink>
-    </Link>
+  <StyledLanguageMenu>
+    <EnTextWrapper>
+      <Link href={currentUrlPath} locale="en" prefetch={false}>
+        <EnText data-gtm-click="language-menu-en-link">
+          {language === 'en' ? <FaAngleRight /> : ''}
+          English
+        </EnText>
+      </Link>
+      <EnText>
+        {language === 'en' ? <FaAngleRight /> : ''}
+        English
+      </EnText>
+    </EnTextWrapper>
+    <Separator />
+    <JaTextWrapper>
+      <Link href={currentUrlPath} locale="ja" prefetch={false}>
+        <JaText data-gtm-click="language-menu-ja-link">
+          {language === 'ja' ? <FaAngleRight /> : ''}
+          日本語
+        </JaText>
+      </Link>
+    </JaTextWrapper>
   </StyledLanguageMenu>
 );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/191

# Done の定義

- デザイン崩れが修正されている事

# スクリーンショット or Storybook の URL

- https://62729802bbcc7d004a663d4c-mxlqjxftlh.chromatic.com/?path=/story/components-header--language-ja-menu-is-open
- https://62729802bbcc7d004a663d4c-mxlqjxftlh.chromatic.com/?path=/story/components-header--language-en-menu-is-open

# 変更点概要

https://github.com/nekochans/lgtm-cat-ui/pull/192 で行った対応の結果、デザインが崩れてしまったので、元の形をベースに修正。

https://mikemai.net/cpac に載っているように `ul` を使うようにしたのが原因だった模様。

https://mikemai.net/cpac で紹介されている `nav` を使った形に修正。

ちなみにこれが正しいのかどうかは分からない、もっと良い方法が見つかればマークアップの修正を行う予定。

今回のようにデザイン崩れが起きた時に気がつけるように言語メニューを開いた状態のStoryを追加。

# レビュアーに重点的にチェックして欲しい点

アクセシビリティを考慮した言語メニューのマークアップ構造案でもっと良い方法があれば教えてもらえると:pray:

# 補足情報

特になし