### PR TITLE
Cats Random Copiedを押下した後のメッセージ位置の調整

### DIFF
--- a/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
+++ b/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
@@ -19,7 +19,7 @@ const DefaultWrapper = styled.div`
 
 const UpperWrapper = styled.div`
   ${baseCss};
-  top: 30%;
+  top: 15%;
   opacity: 0.5;
 `;
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/202

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/202 に記載してある通りメッセージが隠れてしまう現象が解消されている事

# スクリーンショット or Storybook の URL

## スクリーンサイズがかなり大きくてもメッセージが隠れていないので大丈夫だと思われる

https://user-images.githubusercontent.com/11032365/194757896-815b87d0-416e-49b0-9a54-0a0dede909c1.mov

# 変更点概要

スクリーンショットに貼った動画の通り、`Cats Random Copied` を押下した際のメッセージ位置を調整した。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし