### PR TITLE
styled-componentsで生成されたComponentの命名規則を変更

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,13 @@
     "project": ["./tsconfig.json"],
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint", "jsx-a11y", "react", "react-hooks"],
+  "plugins": [
+    "@typescript-eslint",
+    "jsx-a11y",
+    "react",
+    "react-hooks",
+    "styled-components-varname"
+  ],
   "rules": {
     "padding-line-between-statements": [
       "error",
@@ -117,7 +123,8 @@
         }
       }
     ],
-    "react/display-name": "off"
+    "react/display-name": "off",
+    "styled-components-varname/varname": 2
   },
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-plugin-react": "^7.31.8",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-storybook": "^0.6.4",
+        "eslint-plugin-styled-components-varname": "^1.0.1",
         "jest": "^29.1.2",
         "next": "^12.3.1",
         "npm-run-all": "^4.1.5",
@@ -16765,6 +16766,27 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/eslint-plugin-styled-components-varname": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-styled-components-varname/-/eslint-plugin-styled-components-varname-1.0.1.tgz",
+      "integrity": "sha512-W4wUa3ZqhpgFNY98UCnI+CNdOsuqh2zv2m5ZZNs9U4zymdOAmZEQfT/pmKF+qqWSsjoGg/XFl81Go7vrpJBeBw==",
+      "dev": true,
+      "dependencies": {
+        "requireindex": "~1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-styled-components-varname/node_modules/requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/eslint-scope": {
@@ -45721,6 +45743,23 @@
           "requires": {
             "lodash": "^4.17.15"
           }
+        }
+      }
+    },
+    "eslint-plugin-styled-components-varname": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-styled-components-varname/-/eslint-plugin-styled-components-varname-1.0.1.tgz",
+      "integrity": "sha512-W4wUa3ZqhpgFNY98UCnI+CNdOsuqh2zv2m5ZZNs9U4zymdOAmZEQfT/pmKF+qqWSsjoGg/XFl81Go7vrpJBeBw==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.1.0"
+      },
+      "dependencies": {
+        "requireindex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+          "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-react": "^7.31.8",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-storybook": "^0.6.4",
+    "eslint-plugin-styled-components-varname": "^1.0.1",
     "jest": "^29.1.2",
     "next": "^12.3.1",
     "npm-run-all": "^4.1.5",

--- a/src/components/Button/CatButtonGroup/CatButtonGroup.tsx
+++ b/src/components/Button/CatButtonGroup/CatButtonGroup.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { CatFetchButton } from '../CatFetchButton';
 import { UploadCatButton } from '../UploadCatButton';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   @media (max-width: 767px) {
     display: flex;
     flex-direction: column;
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
   background: #fff;
 `;
 
-const ButtonGroup = styled.div`
+const _ButtonGroup = styled.div`
   @media (max-width: 767px) {
     flex: none;
     flex-direction: column;
@@ -39,14 +39,14 @@ export const CatButtonGroup: FC<Props> = ({
   onClickFetchRandomCatButton,
   onClickFetchNewArrivalCatButton,
 }) => (
-  <Wrapper>
-    <ButtonGroup>
+  <_Wrapper>
+    <_ButtonGroup>
       <UploadCatButton
         link="/upload"
         customDataAttrGtmClick="top-upload-cat-button"
       />
       <CatFetchButton type="refresh" onClick={onClickFetchRandomCatButton} />
       <CatFetchButton type="new" onClick={onClickFetchNewArrivalCatButton} />
-    </ButtonGroup>
-  </Wrapper>
+    </_ButtonGroup>
+  </_Wrapper>
 );

--- a/src/components/Button/CatFetchButton/CatFetchButton.tsx
+++ b/src/components/Button/CatFetchButton/CatFetchButton.tsx
@@ -5,12 +5,12 @@ import styled from 'styled-components';
 import { mixins } from '../../../styles';
 import { assertNever } from '../../../utils';
 
-const StyledButton = styled.button`
+const _Button = styled.button`
   background: #eb7c06;
   ${mixins.buttonBase};
 `;
 
-const Text = styled.div`
+const _Text = styled.div`
   ${mixins.buttonText};
 `;
 
@@ -44,8 +44,8 @@ type Props = {
 };
 
 export const CatFetchButton: FC<Props> = ({ type, onClick }) => (
-  <StyledButton onClick={onClick}>
+  <_Button onClick={onClick}>
     <FaSyncAlt style={faSyncAltStyle} />
-    <Text>{buttonText(type)}</Text>
-  </StyledButton>
+    <_Text>{buttonText(type)}</_Text>
+  </_Button>
 );

--- a/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
+++ b/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
@@ -12,13 +12,13 @@ import slash from '../images/slash.png';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
 const slashSrc = slash.src;
 
-const StyledButton = styled.button`
+const _Button = styled.button`
   ${mixins.buttonBase};
   width: 227px;
   background: #eb7c06 url(${slashSrc}) repeat 0 0/16px auto;
 `;
 
-const Text = styled.div`
+const _Text = styled.div`
   ${mixins.buttonText};
 `;
 
@@ -54,10 +54,10 @@ export const CatRandomCopyButton: FC<Props> = ({
 
   return (
     <>
-      <StyledButton ref={imageContextRef}>
+      <_Button ref={imageContextRef}>
         <FaRandom style={faRandomStyle} />
-        <Text>Cats Random Copied</Text>
-      </StyledButton>
+        <_Text>Cats Random Copied</_Text>
+      </_Button>
       {copied ? <CopiedGithubMarkdownMessage position="upper" /> : ''}
     </>
   );

--- a/src/components/Button/GitHubLoginButton/GitHubLoginButton.tsx
+++ b/src/components/Button/GitHubLoginButton/GitHubLoginButton.tsx
@@ -4,12 +4,12 @@ import styled from 'styled-components';
 
 import { mixins } from '../../../styles';
 
-const StyledGitHubLoginButton = styled.button`
+const _Button = styled.button`
   background: #eb7c06;
   ${mixins.buttonBase};
 `;
 
-const Text = styled.div`
+const _Text = styled.div`
   ${mixins.buttonText};
 `;
 
@@ -25,8 +25,8 @@ const faGithubStyle = {
 };
 
 export const GitHubLoginButton: FC = () => (
-  <StyledGitHubLoginButton>
+  <_Button>
     <FaGithub style={faGithubStyle} />
-    <Text>Login</Text>
-  </StyledGitHubLoginButton>
+    <_Text>Login</_Text>
+  </_Button>
 );

--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -10,12 +10,12 @@ import slash from '../images/slash.png';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
 const slashSrc = slash.src;
 
-const StyledSpan = styled.span`
+const _Span = styled.span`
   background: #eb7c06 url(${slashSrc}) repeat 0 0/16px auto;
   ${mixins.buttonBase};
 `;
 
-const Text = styled.div`
+const _Text = styled.div`
   ${mixins.buttonText};
 `;
 
@@ -40,12 +40,12 @@ export const UploadCatButton: FC<Props> = ({
   customDataAttrGtmClick,
 }) => (
   <Link href={link} prefetch={false}>
-    <StyledSpan data-gtm-click={customDataAttrGtmClick}>
+    <_Span data-gtm-click={customDataAttrGtmClick}>
       <FaCloudUploadAlt
         style={faCloudUploadAltStyle}
         data-gtm-click={customDataAttrGtmClick}
       />
-      <Text data-gtm-click={customDataAttrGtmClick}>Upload new Cats</Text>
-    </StyledSpan>
+      <_Text data-gtm-click={customDataAttrGtmClick}>Upload new Cats</_Text>
+    </_Span>
   </Link>
 );

--- a/src/components/ErrorContent/BackToTopButton.tsx
+++ b/src/components/ErrorContent/BackToTopButton.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import type { Language } from '../../types';
 import { assertNever } from '../../utils';
 
-const StyledSpan = styled.span`
+const _Span = styled.span`
   display: flex;
   flex-direction: row;
   gap: 10px;
@@ -20,7 +20,7 @@ const StyledSpan = styled.span`
   }
 `;
 
-const Text = styled.div`
+const _Text = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -62,8 +62,8 @@ type Props = {
 
 export const BackToTopButton: FC<Props> = ({ language }) => (
   <Link href="/" prefetch={false}>
-    <StyledSpan>
-      <Text>{createBackToTopPageText(language)}</Text>
-    </StyledSpan>
+    <_Span>
+      <_Text>{createBackToTopPageText(language)}</_Text>
+    </_Span>
   </Link>
 );

--- a/src/components/ErrorContent/ErrorContent.tsx
+++ b/src/components/ErrorContent/ErrorContent.tsx
@@ -7,7 +7,7 @@ import { assertNever } from '../../utils';
 
 import { BackToTopButton } from './BackToTopButton';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 64px;
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
   justify-content: center;
 `;
 
-const Title = styled.div`
+const _Title = styled.div`
   font-family: Roboto, sans-serif;
   font-size: 70px;
   font-style: normal;
@@ -25,13 +25,13 @@ const Title = styled.div`
   text-align: center;
 `;
 
-const ImageWrapper = styled.div`
+const _ImageWrapper = styled.div`
   position: relative;
   width: 240px;
   height: 240px;
 `;
 
-const Message = styled.div`
+const _Message = styled.div`
   font-family: Roboto, sans-serif;
   font-size: 16px;
   font-style: normal;
@@ -138,14 +138,14 @@ export const ErrorContent: FC<Props> = ({
   language,
   shouldDisplayBackToTopButton,
 }) => (
-  <Wrapper>
-    <Title>{createErrorTitleText(type)}</Title>
-    <ImageWrapper>{catImage}</ImageWrapper>
-    <Message>{createErrorMessageText(type, language)}</Message>
+  <_Wrapper>
+    <_Title>{createErrorTitleText(type)}</_Title>
+    <_ImageWrapper>{catImage}</_ImageWrapper>
+    <_Message>{createErrorMessageText(type, language)}</_Message>
     {shouldDisplayBackToTopButton ? (
       <BackToTopButton language={language} />
     ) : (
       ''
     )}
-  </Wrapper>
+  </_Wrapper>
 );

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -9,7 +9,7 @@ import {
 
 import type { Language } from '../../types';
 
-const StyledFooter = styled.div`
+const _Wrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -17,7 +17,7 @@ const StyledFooter = styled.div`
   justify-content: center;
 `;
 
-const UpperSection = styled.div`
+const _UpperSection = styled.div`
   display: flex;
   flex: none;
   flex-direction: row;
@@ -30,7 +30,7 @@ const UpperSection = styled.div`
   background: #fffcf6;
 `;
 
-const TermsLinkText = styled.a`
+const _TermsLinkText = styled.a`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -46,7 +46,7 @@ const TermsLinkText = styled.a`
   cursor: pointer;
 `;
 
-const PrivacyLinkText = styled.a`
+const _PrivacyLinkText = styled.a`
   flex: none;
   flex-grow: 0;
   order: 2;
@@ -62,7 +62,7 @@ const PrivacyLinkText = styled.a`
   cursor: pointer;
 `;
 
-const SeparatorText = styled.div`
+const _SeparatorText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 1;
@@ -77,7 +77,7 @@ const SeparatorText = styled.div`
   text-align: center;
 `;
 
-const LowerSection = styled.div`
+const _LowerSection = styled.div`
   display: flex;
   flex: none;
   flex-direction: row;
@@ -91,7 +91,7 @@ const LowerSection = styled.div`
   background: #f2ebdf;
 `;
 
-const LowerSectionText = styled.div`
+const _LowerSectionText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -115,24 +115,24 @@ export const Footer: FC<Props> = ({ language }) => {
   const privacy = createPrivacyPolicyLinksFromLanguages(language);
 
   return (
-    <StyledFooter>
-      <UpperSection>
+    <_Wrapper>
+      <_UpperSection>
         <Link href={terms.link} prefetch={false}>
-          <TermsLinkText data-gtm-click="footer-terms-link">
+          <_TermsLinkText data-gtm-click="footer-terms-link">
             {terms.text}
-          </TermsLinkText>
+          </_TermsLinkText>
         </Link>
         {/* eslint-disable no-irregular-whitespace */}
-        <SeparatorText> / </SeparatorText>
+        <_SeparatorText> / </_SeparatorText>
         <Link href={privacy.link} prefetch={false}>
-          <PrivacyLinkText data-gtm-click="footer-privacy-link">
+          <_PrivacyLinkText data-gtm-click="footer-privacy-link">
             {privacy.text}
-          </PrivacyLinkText>
+          </_PrivacyLinkText>
         </Link>
-      </UpperSection>
-      <LowerSection>
-        <LowerSectionText>Copyright (c) nekochans</LowerSectionText>
-      </LowerSection>
-    </StyledFooter>
+      </_UpperSection>
+      <_LowerSection>
+        <_LowerSectionText>Copyright (c) nekochans</_LowerSectionText>
+      </_LowerSection>
+    </_Wrapper>
   );
 };

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -10,7 +10,7 @@ import {
 
 import type { Language } from '../../types';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -22,7 +22,7 @@ const Wrapper = styled.div`
   padding: 10px 22px 7px 0;
 `;
 
-const HeaderWrapper = styled.div`
+const _HeaderWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -31,7 +31,7 @@ const HeaderWrapper = styled.div`
   padding: 10px 22px 7px 0;
 `;
 
-const FaTimesWrapper = styled.div`
+const _FaTimesWrapper = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -48,7 +48,7 @@ const faTimesStyle = {
   cursor: 'pointer',
 };
 
-const LinkGroupWrapper = styled.div`
+const _LinkGroupWrapper = styled.div`
   position: absolute;
   top: 73px;
   left: 15px;
@@ -60,7 +60,7 @@ const LinkGroupWrapper = styled.div`
   padding: 0;
 `;
 
-const LinkWrapper = styled.div`
+const _LinkWrapper = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -68,7 +68,7 @@ const LinkWrapper = styled.div`
   height: 45px;
 `;
 
-const LinkText = styled.a`
+const _LinkText = styled.a`
   display: flex;
   align-items: center;
   font-family: Roboto, sans-serif;
@@ -81,7 +81,7 @@ const LinkText = styled.a`
   cursor: pointer;
 `;
 
-const UnderLine = styled.div`
+const _UnderLine = styled.div`
   box-sizing: border-box;
   background: #faf9f7;
   border-bottom: 1px solid #f2ebdf;
@@ -108,45 +108,45 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
   const privacyPolicyLinks = createPrivacyPolicyLinksFromLanguages(language);
 
   return (
-    <Wrapper>
-      <HeaderWrapper>
-        <FaTimesWrapper onClick={onClickCloseButton}>
+    <_Wrapper>
+      <_HeaderWrapper>
+        <_FaTimesWrapper onClick={onClickCloseButton}>
           <FaTimes style={faTimesStyle} />
-        </FaTimesWrapper>
-      </HeaderWrapper>
-      <LinkGroupWrapper>
-        <LinkWrapper>
+        </_FaTimesWrapper>
+      </_HeaderWrapper>
+      <_LinkGroupWrapper>
+        <_LinkWrapper>
           <Link href="/" prefetch={false}>
-            <LinkText data-gtm-click="global-menu-top-link">TOP</LinkText>
+            <_LinkText data-gtm-click="global-menu-top-link">TOP</_LinkText>
           </Link>
-          <UnderLine />
-        </LinkWrapper>
-        <LinkWrapper>
+          <_UnderLine />
+        </_LinkWrapper>
+        <_LinkWrapper>
           <Link href="/upload" prefetch={false}>
-            <LinkText data-gtm-click="global-menu-upload-cat-link">
+            <_LinkText data-gtm-click="global-menu-upload-cat-link">
               <FaCloudUploadAlt style={faCloudUploadAltStyle} />
               Upload new Cats
-            </LinkText>
+            </_LinkText>
           </Link>
-          <UnderLine />
-        </LinkWrapper>
-        <LinkWrapper>
+          <_UnderLine />
+        </_LinkWrapper>
+        <_LinkWrapper>
           <Link href={termsOfUseLinks.link} prefetch={false}>
-            <LinkText data-gtm-click="global-menu-terms-link">
+            <_LinkText data-gtm-click="global-menu-terms-link">
               {termsOfUseLinks.text}
-            </LinkText>
+            </_LinkText>
           </Link>
-          <UnderLine />
-        </LinkWrapper>
-        <LinkWrapper>
+          <_UnderLine />
+        </_LinkWrapper>
+        <_LinkWrapper>
           <Link href={privacyPolicyLinks.link} prefetch={false}>
-            <LinkText data-gtm-click="global-menu-terms-link">
+            <_LinkText data-gtm-click="global-menu-terms-link">
               {privacyPolicyLinks.text}
-            </LinkText>
+            </_LinkText>
           </Link>
-          <UnderLine />
-        </LinkWrapper>
-      </LinkGroupWrapper>
-    </Wrapper>
+          <_UnderLine />
+        </_LinkWrapper>
+      </_LinkGroupWrapper>
+    </_Wrapper>
   );
 };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -9,11 +9,11 @@ import { GlobalMenu } from '../GlobalMenu';
 import { LanguageButton } from './LanguageButton';
 import { LanguageMenu, Props as LanguageMenuProps } from './LanguageMenu';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   background: #e9e2d7;
 `;
 
-const StyledHeader = styled.div`
+const _Header = styled.div`
   position: relative;
   display: flex;
   flex-direction: row;
@@ -24,7 +24,7 @@ const StyledHeader = styled.div`
   margin: 0 auto;
 `;
 
-const Title = styled.a`
+const _Title = styled.a`
   position: absolute;
   top: 26.67%;
   bottom: 26.67%;
@@ -98,11 +98,11 @@ export const Header: FC<Props> = ({
       >
         <GlobalMenu language={language} onClickCloseButton={closeMenu} />
       </Modal>
-      <Wrapper>
-        <StyledHeader>
+      <_Wrapper>
+        <_Header>
           <FaBars style={faBarsStyle} onClick={openMenu} />
           <Link href="/" prefetch={false}>
-            <Title data-gtm-click="header-app-title">LGTMeow</Title>
+            <_Title data-gtm-click="header-app-title">LGTMeow</_Title>
           </Link>
           <LanguageButton onClick={onClickLanguageButton} />
           {isLanguageMenuDisplayed ? (
@@ -110,8 +110,8 @@ export const Header: FC<Props> = ({
           ) : (
             ''
           )}
-        </StyledHeader>
-      </Wrapper>
+        </_Header>
+      </_Wrapper>
     </>
   );
 };

--- a/src/components/Header/LanguageButton.tsx
+++ b/src/components/Header/LanguageButton.tsx
@@ -2,7 +2,7 @@ import type { FC, MouseEvent } from 'react';
 import { FaCaretDown } from 'react-icons/fa';
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   @media (max-width: 767px) {
     padding: 12px 0;
   }
@@ -19,7 +19,7 @@ const Wrapper = styled.div`
   border-radius: 4px;
 `;
 
-const Text = styled.p`
+const _Text = styled.p`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -42,8 +42,8 @@ type Props = {
 };
 
 export const LanguageButton: FC<Props> = ({ onClick }) => (
-  <Wrapper onClick={onClick}>
-    <Text>Language</Text>
+  <_Wrapper onClick={onClick}>
+    <_Text>Language</_Text>
     <FaCaretDown style={faCaretDownStyle} />
-  </Wrapper>
+  </_Wrapper>
 );

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -17,7 +17,7 @@ const textWrapperStyle = css`
   background: rgba(54, 46, 43, 0.4);
 `;
 
-const StyledLanguageMenu = styled.nav`
+const _Wrapper = styled.nav`
   @media (max-width: 767px) {
     right: 0;
   }
@@ -30,12 +30,12 @@ const StyledLanguageMenu = styled.nav`
   padding: 0;
 `;
 
-const EnTextWrapper = styled.span`
+const _EnTextWrapper = styled.span`
   ${textWrapperStyle};
   order: 0;
 `;
 
-const EnText = styled.a`
+const _EnText = styled.a`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -51,7 +51,7 @@ const EnText = styled.a`
   cursor: pointer;
 `;
 
-const Separator = styled.span`
+const _Separator = styled.span`
   flex: none;
   flex-grow: 0;
   order: 1;
@@ -60,12 +60,12 @@ const Separator = styled.span`
   border: 1px solid rgba(54, 46, 43, 0.5);
 `;
 
-const JaTextWrapper = styled.span`
+const _JaTextWrapper = styled.span`
   ${textWrapperStyle};
   order: 2;
 `;
 
-const JaText = styled.a`
+const _JaText = styled.a`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -87,27 +87,27 @@ export type Props = {
 };
 
 export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
-  <StyledLanguageMenu>
-    <EnTextWrapper>
+  <_Wrapper>
+    <_EnTextWrapper>
       <Link href={currentUrlPath} locale="en" prefetch={false}>
-        <EnText data-gtm-click="language-menu-en-link">
+        <_EnText data-gtm-click="language-menu-en-link">
           {language === 'en' ? <FaAngleRight /> : ''}
           English
-        </EnText>
+        </_EnText>
       </Link>
-      <EnText>
+      <_EnText>
         {language === 'en' ? <FaAngleRight /> : ''}
         English
-      </EnText>
-    </EnTextWrapper>
-    <Separator />
-    <JaTextWrapper>
+      </_EnText>
+    </_EnTextWrapper>
+    <_Separator />
+    <_JaTextWrapper>
       <Link href={currentUrlPath} locale="ja" prefetch={false}>
-        <JaText data-gtm-click="language-menu-ja-link">
+        <_JaText data-gtm-click="language-menu-ja-link">
           {language === 'ja' ? <FaAngleRight /> : ''}
           日本語
-        </JaText>
+        </_JaText>
       </Link>
-    </JaTextWrapper>
-  </StyledLanguageMenu>
+    </_JaTextWrapper>
+  </_Wrapper>
 );

--- a/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
+++ b/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
@@ -12,12 +12,12 @@ const baseCss = css`
   transform: translate(-50%, 0);
 `;
 
-const DefaultWrapper = styled.div`
+const _DefaultWrapper = styled.div`
   ${baseCss};
   bottom: 30%;
 `;
 
-const UpperWrapper = styled.div`
+const _UpperWrapper = styled.div`
   ${baseCss};
   top: 15%;
   opacity: 0.5;
@@ -35,9 +35,9 @@ export const CopiedGithubMarkdownMessage: FC<Props> = ({
   return (
     <>
       {position === 'default' ? (
-        <DefaultWrapper>{text}</DefaultWrapper>
+        <_DefaultWrapper>{text}</_DefaultWrapper>
       ) : (
-        <UpperWrapper>{text}</UpperWrapper>
+        <_UpperWrapper>{text}</_UpperWrapper>
       )}
     </>
   );

--- a/src/components/LgtmImages/LgtmImageContent.tsx
+++ b/src/components/LgtmImages/LgtmImageContent.tsx
@@ -8,7 +8,7 @@ import { useClipboardMarkdown, useCopySuccess } from '../../hooks';
 import type { LgtmImage } from '../../types';
 import { CopiedGithubMarkdownMessage } from './CopiedGithubMarkdownMessage';
 
-const ImageWrapper = styled.div`
+const _Wrapper = styled.div`
   position: relative;
   height: 300px;
   cursor: pointer;
@@ -37,7 +37,7 @@ export const LgtmImageContent: FC<Props> = ({
   });
 
   return (
-    <ImageWrapper key={id} ref={imageContextRef}>
+    <_Wrapper key={id} ref={imageContextRef}>
       <Image
         src={imageUrl}
         layout="fill"
@@ -46,6 +46,6 @@ export const LgtmImageContent: FC<Props> = ({
         priority={true}
       />
       {copied ? <CopiedGithubMarkdownMessage /> : ''}
-    </ImageWrapper>
+    </_Wrapper>
   );
 };

--- a/src/components/LgtmImages/LgtmImages.tsx
+++ b/src/components/LgtmImages/LgtmImages.tsx
@@ -5,7 +5,7 @@ import type { AppUrl } from '../../constants';
 import type { LgtmImage } from '../../types';
 import { LgtmImageContent } from './LgtmImageContent';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   @media (max-width: 767px) {
     grid-template-columns: 1fr;
     gap: 10px;
@@ -22,7 +22,7 @@ type Props = {
 };
 
 export const LgtmImages: FC<Props> = ({ images, appUrl, callback }) => (
-  <Wrapper>
+  <_Wrapper>
     {images.map((image) => (
       <LgtmImageContent
         id={image.id}
@@ -32,5 +32,5 @@ export const LgtmImages: FC<Props> = ({ images, appUrl, callback }) => (
         callback={callback}
       />
     ))}
-  </Wrapper>
+  </_Wrapper>
 );

--- a/src/components/MarkdownContents/MarkdownContents.tsx
+++ b/src/components/MarkdownContents/MarkdownContents.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -24,7 +24,7 @@ export type Props = {
 };
 
 export const MarkdownContents: FC<Props> = ({ markdown }) => (
-  <Wrapper className="markdown">
+  <_Wrapper className="markdown">
     <ReactMarkdown>{markdown}</ReactMarkdown>
-  </Wrapper>
+  </_Wrapper>
 );

--- a/src/components/MarkdownPageTitle/MarkdownPageTitle.tsx
+++ b/src/components/MarkdownPageTitle/MarkdownPageTitle.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import styled from 'styled-components';
 
-const StyledTitle = styled.h1`
+const _Title = styled.h1`
   font-family: Roboto, sans-serif;
   font-size: 16px;
   font-style: normal;
@@ -15,5 +15,5 @@ export type Props = {
 };
 
 export const MarkdownPageTitle: FC<Props> = ({ text }) => (
-  <StyledTitle>{text}</StyledTitle>
+  <_Title>{text}</_Title>
 );

--- a/src/components/Upload/UploadButton/UploadButton.tsx
+++ b/src/components/Upload/UploadButton/UploadButton.tsx
@@ -21,7 +21,7 @@ const hoverCss = css`
   }
 `;
 
-const Button = styled.button`
+const _Button = styled.button`
   ${buttonCss};
   ${hoverCss};
 `;
@@ -40,7 +40,7 @@ const buttonTextCss = css`
   color: #fff;
 `;
 
-const Text = styled.div`
+const _Text = styled.div`
   ${buttonTextCss};
   ${hoverCss};
 `;
@@ -49,12 +49,12 @@ const disableCss = css`
   opacity: 0.5;
 `;
 
-const DisableButton = styled.button`
+const _DisableButton = styled.button`
   ${buttonCss};
   ${disableCss};
 `;
 
-const DisableText = styled.div`
+const _DisableText = styled.div`
   ${buttonTextCss};
   ${disableCss};
 `;
@@ -79,15 +79,15 @@ type Props = {
 export const UploadButton: FC<Props> = ({ language, disabled, onClick }) => {
   if (!disabled) {
     return (
-      <Button type="submit" disabled={disabled} onClick={onClick}>
-        <Text>{createText(language)}</Text>
-      </Button>
+      <_Button type="submit" disabled={disabled} onClick={onClick}>
+        <_Text>{createText(language)}</_Text>
+      </_Button>
     );
   }
 
   return (
-    <DisableButton type="submit" disabled={disabled} onClick={onClick}>
-      <DisableText>{createText(language)}</DisableText>
-    </DisableButton>
+    <_DisableButton type="submit" disabled={disabled} onClick={onClick}>
+      <_DisableText>{createText(language)}</_DisableText>
+    </_DisableButton>
   );
 };

--- a/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
+++ b/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
@@ -6,7 +6,7 @@ type Props = {
   messages: string[];
 };
 
-const StyledUploadErrorMessageArea = styled.div`
+const _Wrapper = styled.div`
   @media (max-width: 767px) {
     width: 380px;
   }
@@ -38,7 +38,7 @@ const faExclamationTriangleStyle = {
   flexGrow: 0,
 };
 
-const MessageText = styled.span`
+const _MessageText = styled.span`
   @media (max-width: 767px) {
     width: 380px;
   }
@@ -57,12 +57,12 @@ const MessageText = styled.span`
 `;
 
 export const UploadErrorMessageArea: FC<Props> = ({ messages }) => (
-  <StyledUploadErrorMessageArea>
+  <_Wrapper>
     <FaExclamationTriangle style={faExclamationTriangleStyle} />
-    <MessageText>
+    <_MessageText>
       {messages.map((message, index) => (
         <p key={index}>{message}</p>
       ))}
-    </MessageText>
-  </StyledUploadErrorMessageArea>
+    </_MessageText>
+  </_Wrapper>
 );

--- a/src/components/Upload/UploadForm/StyledComponents.tsx
+++ b/src/components/Upload/UploadForm/StyledComponents.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Wrapper = styled.div`
+export const _Wrapper = styled.div`
   display: flex;
   flex: none;
   flex-direction: column;
@@ -11,7 +11,7 @@ export const Wrapper = styled.div`
   padding: 0;
 `;
 
-export const Form = styled.form`
+export const _Form = styled.form`
   @media (max-width: 767px) {
     width: 380px;
   }
@@ -21,7 +21,7 @@ export const Form = styled.form`
   width: 500px;
 `;
 
-export const InputFileArea = styled.div`
+export const _InputFileArea = styled.div`
   box-sizing: border-box;
   display: grid;
   height: 220px;
@@ -29,7 +29,7 @@ export const InputFileArea = styled.div`
   border: 1px dashed #362e2b;
 `;
 
-export const Text = styled.div`
+export const _Text = styled.div`
   font-family: Roboto, sans-serif;
   font-size: 16px;
   font-style: normal;
@@ -39,11 +39,11 @@ export const Text = styled.div`
   text-align: center;
 `;
 
-export const InputFile = styled.input`
+export const _InputFile = styled.input`
   display: none;
 `;
 
-export const InputFileLabel = styled.label`
+export const _InputFileLabel = styled.label`
   top: 0;
   right: 0;
   bottom: 0;
@@ -63,7 +63,7 @@ export const InputFileLabel = styled.label`
   border-radius: 4px;
 `;
 
-export const InputFileLabelText = styled.div`
+export const _InputFileLabelText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -77,7 +77,7 @@ export const InputFileLabelText = styled.div`
   color: #f0a14e;
 `;
 
-export const MaxUploadSizeText = styled.div`
+export const _MaxUploadSizeText = styled.div`
   height: 28px;
   font-family: Roboto, sans-serif;
   font-size: 13px;
@@ -88,7 +88,7 @@ export const MaxUploadSizeText = styled.div`
   text-align: right;
 `;
 
-export const CautionTextArea = styled.div`
+export const _CautionTextArea = styled.div`
   height: 28px;
   font-family: Roboto, sans-serif;
   font-size: 14px;
@@ -99,7 +99,7 @@ export const CautionTextArea = styled.div`
   text-align: center;
 `;
 
-export const Notes = styled.div`
+export const _Notes = styled.div`
   top: 609px;
   height: 96px;
   font-family: Roboto, sans-serif;
@@ -110,12 +110,12 @@ export const Notes = styled.div`
   color: #362e2b;
 `;
 
-export const DescriptionAreaWrapper = styled.div`
+export const _DescriptionAreaWrapper = styled.div`
   display: grid;
   gap: 24px;
 `;
 
-export const PrivacyPolicyArea = styled.div`
+export const _PrivacyPolicyArea = styled.div`
   height: 42px;
   font-family: Roboto, sans-serif;
   font-size: 12px;
@@ -126,7 +126,7 @@ export const PrivacyPolicyArea = styled.div`
   text-align: center;
 `;
 
-export const PrivacyLinkText = styled.a`
+export const _PrivacyLinkText = styled.a`
   height: 42px;
   font-family: Roboto, sans-serif;
   font-size: 12px;
@@ -139,7 +139,7 @@ export const PrivacyLinkText = styled.a`
   cursor: pointer;
 `;
 
-export const UploadButtonWrapper = styled.div`
+export const _UploadButtonWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -24,20 +24,20 @@ import { UploadModal } from '../UploadModal';
 import { UploadTitleArea } from '../UploadTitleArea';
 
 import {
-  CautionTextArea,
-  DescriptionAreaWrapper,
-  Form,
-  InputFile,
-  InputFileArea,
-  InputFileLabel,
-  InputFileLabelText,
-  MaxUploadSizeText,
-  Notes,
-  PrivacyLinkText,
-  PrivacyPolicyArea,
-  Text,
-  UploadButtonWrapper,
-  Wrapper,
+  _CautionTextArea,
+  _DescriptionAreaWrapper,
+  _Form,
+  _InputFile,
+  _InputFileArea,
+  _InputFileLabel,
+  _InputFileLabelText,
+  _MaxUploadSizeText,
+  _Notes,
+  _PrivacyLinkText,
+  _PrivacyPolicyArea,
+  _Text,
+  _UploadButtonWrapper,
+  _Wrapper,
 } from './StyledComponents';
 import {
   cautionText,
@@ -67,23 +67,23 @@ export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
   switch (language) {
     case 'ja':
       return (
-        <PrivacyPolicyArea>
+        <_PrivacyPolicyArea>
           アップロードするボタンを押下することで{' '}
           <Link href={privacyLinkAttribute.link} prefetch={false}>
-            <PrivacyLinkText>{privacyLinkAttribute.text}</PrivacyLinkText>
+            <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
           </Link>{' '}
           に同意したと見なします
-        </PrivacyPolicyArea>
+        </_PrivacyPolicyArea>
       );
     case 'en':
       return (
-        <PrivacyPolicyArea>
+        <_PrivacyPolicyArea>
           By pressing the upload button, you agree to the{' '}
           <Link href={privacyLinkAttribute.link} prefetch={false}>
-            <PrivacyLinkText>{privacyLinkAttribute.text}</PrivacyLinkText>
+            <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
           </Link>{' '}
           .
-        </PrivacyPolicyArea>
+        </_PrivacyPolicyArea>
       );
     default:
       return assertNever(language);
@@ -283,7 +283,7 @@ export const UploadForm: FC<Props> = ({
   const { getRootProps } = useDropzone({ onDrop });
 
   return (
-    <Wrapper>
+    <_Wrapper>
       {/* eslint-disable no-magic-numbers */}
       {displayErrorMessages.length === 0 ? (
         ''
@@ -291,38 +291,38 @@ export const UploadForm: FC<Props> = ({
         <UploadErrorMessageArea messages={displayErrorMessages} />
       )}
       <UploadTitleArea language={language} />
-      <Form>
+      <_Form>
         {/* eslint-disable-next-line react/jsx-props-no-spreading */}
         <div {...getRootProps()}>
-          <InputFileArea>
+          <_InputFileArea>
             <FaCloudUploadAlt style={faCloudUploadAltStyle} />
-            <Text>{imageDropAreaText(language)}</Text>
-            <InputFileLabel>
-              <InputFileLabelText>
+            <_Text>{imageDropAreaText(language)}</_Text>
+            <_InputFileLabel>
+              <_InputFileLabelText>
                 {uploadInputButtonText(language)}
-              </InputFileLabelText>
-              <InputFile type="file" onChange={handleFileUpload} />
-            </InputFileLabel>
-          </InputFileArea>
+              </_InputFileLabelText>
+              <_InputFile type="file" onChange={handleFileUpload} />
+            </_InputFileLabel>
+          </_InputFileArea>
         </div>
-        <MaxUploadSizeText>Maximum upload size is 4MB</MaxUploadSizeText>
-        <DescriptionAreaWrapper>
-          <CautionTextArea>{cautionText(language)}</CautionTextArea>
-          <Notes>
+        <_MaxUploadSizeText>Maximum upload size is 4MB</_MaxUploadSizeText>
+        <_DescriptionAreaWrapper>
+          <_CautionTextArea>{cautionText(language)}</_CautionTextArea>
+          <_Notes>
             {noteList(language).map((note, index) => (
               <p key={index}>{note}</p>
             ))}
-          </Notes>
+          </_Notes>
           {createPrivacyPolicyArea(language)}
-        </DescriptionAreaWrapper>
-        <UploadButtonWrapper>
+        </_DescriptionAreaWrapper>
+        <_UploadButtonWrapper>
           <UploadButton
             language={language}
             disabled={shouldDisableButton()}
             onClick={onClickUploadButton}
           />
-        </UploadButtonWrapper>
-      </Form>
+        </_UploadButtonWrapper>
+      </_Form>
       {imagePreviewUrl || createdLgtmImageUrl ? (
         <UploadModal
           isOpen={modalIsOpen}
@@ -341,6 +341,6 @@ export const UploadForm: FC<Props> = ({
       ) : (
         ''
       )}
-    </Wrapper>
+    </_Wrapper>
   );
 };

--- a/src/components/Upload/UploadModal/ButtonGroup.tsx
+++ b/src/components/Upload/UploadModal/ButtonGroup.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import type { Language } from '../../../types';
 import { assertNever } from '../../../utils';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   display: flex;
   flex: none;
   flex-direction: row;
@@ -16,7 +16,7 @@ const Wrapper = styled.div`
   padding: 0;
 `;
 
-const CancelButton = styled.button`
+const _CancelButton = styled.button`
   box-sizing: border-box;
   display: flex;
   flex: none;
@@ -35,7 +35,7 @@ const CancelButton = styled.button`
   }
 `;
 
-const CancelButtonText = styled.div`
+const _CancelButtonText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -50,7 +50,7 @@ const CancelButtonText = styled.div`
   }
 `;
 
-const UploadButton = styled.button`
+const _UploadButton = styled.button`
   display: flex;
   flex: none;
   flex-direction: row;
@@ -67,7 +67,7 @@ const UploadButton = styled.button`
   }
 `;
 
-const UploadButtonText = styled.div`
+const _UploadButtonText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -115,12 +115,12 @@ export const ButtonGroup: FC<Props> = ({
   onClickUpload,
   onClickCancel,
 }) => (
-  <Wrapper>
-    <CancelButton onClick={onClickCancel}>
-      <CancelButtonText>{cancelButtonText(language)}</CancelButtonText>
-    </CancelButton>
-    <UploadButton onClick={onClickUpload}>
-      <UploadButtonText>{uploadButtonText(language)}</UploadButtonText>
-    </UploadButton>
-  </Wrapper>
+  <_Wrapper>
+    <_CancelButton onClick={onClickCancel}>
+      <_CancelButtonText>{cancelButtonText(language)}</_CancelButtonText>
+    </_CancelButton>
+    <_UploadButton onClick={onClickUpload}>
+      <_UploadButtonText>{uploadButtonText(language)}</_UploadButtonText>
+    </_UploadButton>
+  </_Wrapper>
 );

--- a/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
+++ b/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
@@ -6,13 +6,13 @@ import { useClipboardMarkdown, useCopySuccess } from '../../../hooks';
 import { LgtmImageUrl } from '../../../types';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
 `;
 
-const StyledImage = styled.img`
+const _Image = styled.img`
   @media (max-width: 767px) {
     max-width: 355px;
   }
@@ -46,9 +46,9 @@ export const CreatedLgtmImage: FC<Props> = ({
 
   return (
     <>
-      <Wrapper ref={imageContextRef}>
-        <StyledImage src={imagePreviewUrl} />
-      </Wrapper>
+      <_Wrapper ref={imageContextRef}>
+        <_Image src={imagePreviewUrl} />
+      </_Wrapper>
       {copied ? <CopiedGithubMarkdownMessage /> : ''}
     </>
   );

--- a/src/components/Upload/UploadModal/SuccessMessageArea.tsx
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.tsx
@@ -7,7 +7,7 @@ import type { Language, LgtmImageUrl } from '../../../types';
 import { assertNever } from '../../../utils';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   display: flex;
   flex: none;
   flex-direction: column;
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
   padding: 0;
 `;
 
-const Title = styled.div`
+const _Title = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -34,7 +34,7 @@ const Title = styled.div`
   color: #eb7c06;
 `;
 
-const ContentsWrapper = styled.div`
+const _ContentsWrapper = styled.div`
   display: flex;
   flex: none;
   flex-direction: column;
@@ -47,7 +47,7 @@ const ContentsWrapper = styled.div`
   padding: 0;
 `;
 
-const MainMessage = styled.div`
+const _MainMessage = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -62,7 +62,7 @@ const MainMessage = styled.div`
   text-align: center;
 `;
 
-const UnderSectionWrapper = styled.div`
+const _UnderSectionWrapper = styled.div`
   display: flex;
   flex: none;
   flex-direction: column;
@@ -75,7 +75,7 @@ const UnderSectionWrapper = styled.div`
   padding: 0;
 `;
 
-const DescriptionWrapper = styled.div`
+const _DescriptionWrapper = styled.div`
   box-sizing: border-box;
   display: flex;
   flex: none;
@@ -92,7 +92,7 @@ const DescriptionWrapper = styled.div`
   border-radius: 3px;
 `;
 
-const DescriptionText = styled.div`
+const _DescriptionText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -106,7 +106,7 @@ const DescriptionText = styled.div`
   color: #8e7e78;
 `;
 
-const ButtonGroup = styled.div`
+const _ButtonGroup = styled.div`
   display: flex;
   flex: none;
   flex-direction: row;
@@ -118,7 +118,7 @@ const ButtonGroup = styled.div`
   padding: 0;
 `;
 
-const CloseButton = styled.button`
+const _CloseButton = styled.button`
   box-sizing: border-box;
   display: flex;
   flex: none;
@@ -134,7 +134,7 @@ const CloseButton = styled.button`
   border-radius: 4px;
 `;
 
-const CloseButtonText = styled.div`
+const _CloseButtonText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -146,7 +146,7 @@ const CloseButtonText = styled.div`
   color: #f0a14e;
 `;
 
-const MarkdownSourceCopyButton = styled.button`
+const _MarkdownSourceCopyButton = styled.button`
   display: flex;
   flex: none;
   flex-direction: row;
@@ -160,7 +160,7 @@ const MarkdownSourceCopyButton = styled.button`
   border-radius: 4px;
 `;
 
-const MarkdownSourceCopyButtonText = styled.div`
+const _MarkdownSourceCopyButtonText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -255,27 +255,27 @@ export const SuccessMessageArea: FC<Props> = ({
   });
 
   return (
-    <Wrapper>
-      <Title>{titleText(language)}</Title>
-      <ContentsWrapper>
-        <MainMessage>{mainMessageText(language)}</MainMessage>
-        <UnderSectionWrapper>
-          <DescriptionWrapper>
-            <DescriptionText>{descriptionText(language)}</DescriptionText>
-          </DescriptionWrapper>
-          <ButtonGroup>
-            <CloseButton onClick={onClickClose}>
-              <CloseButtonText>{closeButtonText(language)}</CloseButtonText>
-            </CloseButton>
-            <MarkdownSourceCopyButton ref={imageContextRef}>
-              <MarkdownSourceCopyButtonText>
+    <_Wrapper>
+      <_Title>{titleText(language)}</_Title>
+      <_ContentsWrapper>
+        <_MainMessage>{mainMessageText(language)}</_MainMessage>
+        <_UnderSectionWrapper>
+          <_DescriptionWrapper>
+            <_DescriptionText>{descriptionText(language)}</_DescriptionText>
+          </_DescriptionWrapper>
+          <_ButtonGroup>
+            <_CloseButton onClick={onClickClose}>
+              <_CloseButtonText>{closeButtonText(language)}</_CloseButtonText>
+            </_CloseButton>
+            <_MarkdownSourceCopyButton ref={imageContextRef}>
+              <_MarkdownSourceCopyButtonText>
                 {markdownSourceCopyButtonText(language)}
-              </MarkdownSourceCopyButtonText>
-            </MarkdownSourceCopyButton>
-          </ButtonGroup>
-        </UnderSectionWrapper>
+              </_MarkdownSourceCopyButtonText>
+            </_MarkdownSourceCopyButton>
+          </_ButtonGroup>
+        </_UnderSectionWrapper>
         {copied ? <CopiedGithubMarkdownMessage /> : ''}
-      </ContentsWrapper>
-    </Wrapper>
+      </_ContentsWrapper>
+    </_Wrapper>
   );
 };

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -26,7 +26,7 @@ export type Props = {
   appUrl?: AppUrl;
 };
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   @media (max-width: 767px) {
     width: 360px;
   }
@@ -42,7 +42,7 @@ const Wrapper = styled.div`
   border: 1px dashed #8e7e78;
 `;
 
-const ContentsWrapper = styled.div`
+const _ContentsWrapper = styled.div`
   display: flex;
   flex: none;
   flex-direction: column;
@@ -53,7 +53,7 @@ const ContentsWrapper = styled.div`
   padding: 0;
 `;
 
-const Title = styled.div`
+const _Title = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -66,7 +66,7 @@ const Title = styled.div`
   text-align: center;
 `;
 
-const FormWrapper = styled.div`
+const _FormWrapper = styled.div`
   display: flex;
   flex: none;
   flex-direction: column;
@@ -77,13 +77,13 @@ const FormWrapper = styled.div`
   padding: 0;
 `;
 
-const PreviewImageWrapper = styled.div`
+const _PreviewImageWrapper = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
 `;
 
-const PreviewImage = styled.img`
+const _PreviewImage = styled.img`
   @media (max-width: 767px) {
     max-width: 355px;
   }
@@ -94,7 +94,7 @@ const PreviewImage = styled.img`
   height: 270px;
 `;
 
-const ConfirmMessage = styled.div`
+const _ConfirmMessage = styled.div`
   flex: none;
   flex-grow: 0;
   order: 1;
@@ -172,10 +172,10 @@ export const UploadModal: FC<Props> = ({
       style={modalStyle}
       onRequestClose={onClickCancel}
     >
-      <Wrapper>
-        <ContentsWrapper>
-          <Title>{titleText(language)}</Title>
-          <FormWrapper>
+      <_Wrapper>
+        <_ContentsWrapper>
+          <_Title>{titleText(language)}</_Title>
+          <_FormWrapper>
             {uploaded ? (
               <CreatedLgtmImage
                 imagePreviewUrl={imagePreviewUrl}
@@ -184,18 +184,20 @@ export const UploadModal: FC<Props> = ({
                 appUrl={appUrl}
               />
             ) : (
-              <PreviewImageWrapper>
-                <PreviewImage src={imagePreviewUrl} />
-              </PreviewImageWrapper>
+              <_PreviewImageWrapper>
+                <_PreviewImage src={imagePreviewUrl} />
+              </_PreviewImageWrapper>
             )}
             {!isLoading && !uploaded ? (
               <>
-                <ConfirmMessage>{confirmMessageText(language)}</ConfirmMessage>
+                <_ConfirmMessage>
+                  {confirmMessageText(language)}
+                </_ConfirmMessage>
               </>
             ) : (
               ''
             )}
-          </FormWrapper>
+          </_FormWrapper>
           {uploaded && createdLgtmImageUrl && !isLoading ? (
             <SuccessMessageArea
               language={language}
@@ -217,8 +219,8 @@ export const UploadModal: FC<Props> = ({
             ''
           )}
           {isLoading ? <UploadProgressBar language={language} /> : ''}
-        </ContentsWrapper>
-      </Wrapper>
+        </_ContentsWrapper>
+      </_Wrapper>
     </Modal>
   );
 };

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import type { Language } from '../../../types';
 import { assertNever } from '../../../utils';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   flex: none;
   flex-grow: 0;
   order: 1;
@@ -12,18 +12,18 @@ const Wrapper = styled.div`
   height: 54px;
 `;
 
-const BarWrapper = styled.div`
+const _BarWrapper = styled.div`
   width: 280px;
   height: 20px;
 `;
 
-const MainColorBar = styled.div`
+const _MainColorBar = styled.div`
   width: 92px;
   height: 18px;
   background: #f0a14e;
 `;
 
-const DefaultColorBar = styled.div`
+const _DefaultColorBar = styled.div`
   box-sizing: border-box;
   width: 280px;
   height: 20px;
@@ -31,7 +31,7 @@ const DefaultColorBar = styled.div`
   border: 1px solid #8e7e78;
 `;
 
-const Message = styled.p`
+const _Message = styled.p`
   width: 56px;
   height: 28px;
   font-family: Roboto, sans-serif;
@@ -80,13 +80,13 @@ export const UploadProgressBar: FC<Props> = ({ language }) => {
   }, [progressLength]);
 
   return (
-    <Wrapper>
-      <BarWrapper>
-        <DefaultColorBar>
-          <MainColorBar style={{ width: `${progressLength}px` }} />
-        </DefaultColorBar>
-      </BarWrapper>
-      <Message>{messageText(language)}</Message>
-    </Wrapper>
+    <_Wrapper>
+      <_BarWrapper>
+        <_DefaultColorBar>
+          <_MainColorBar style={{ width: `${progressLength}px` }} />
+        </_DefaultColorBar>
+      </_BarWrapper>
+      <_Message>{messageText(language)}</_Message>
+    </_Wrapper>
   );
 };

--- a/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
+++ b/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Language } from '../../../types';
 import { assertNever } from '../../../utils';
 
-const StyledUploadTitleArea = styled.div`
+const _Wrapper = styled.div`
   font-family: Roboto, sans-serif;
   font-size: 16px;
   font-style: normal;
@@ -33,5 +33,5 @@ const text = (language: Language): Text => {
 };
 
 export const UploadTitleArea: FC<Props> = ({ language }) => (
-  <StyledUploadTitleArea>{text(language)}</StyledUploadTitleArea>
+  <_Wrapper>{text(language)}</_Wrapper>
 );

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Footer, Props as FooterProps } from '../../components/Footer';
 import { Header, Props as HeaderProps } from '../../components/Header';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   display: grid;
   grid-template-rows: auto 1fr auto;
   grid-template-columns: 100%;
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
   min-height: 100vh;
 `;
 
-const ContentsWrapper = styled.div`
+const _ContentsWrapper = styled.div`
   display: inline-block;
   margin: 0 auto;
   text-align: center;
@@ -28,14 +28,14 @@ export const ResponsiveLayout: FC<Props> = ({
   currentUrlPath,
   children,
 }) => (
-  <Wrapper>
+  <_Wrapper>
     <Header
       language={language}
       isLanguageMenuDisplayed={isLanguageMenuDisplayed}
       onClickLanguageButton={onClickLanguageButton}
       currentUrlPath={currentUrlPath}
     />
-    <ContentsWrapper>{children}</ContentsWrapper>
+    <_ContentsWrapper>{children}</_ContentsWrapper>
     <Footer language={language} />
-  </Wrapper>
+  </_Wrapper>
 );

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -24,7 +24,7 @@ const createTitle = (type: TemplateType, language: Language): string => {
   }
 };
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -32,7 +32,7 @@ const Wrapper = styled.div`
   justify-content: center;
 `;
 
-const ChildrenWrapper = styled.div`
+const _ChildrenWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -79,11 +79,11 @@ export const TermsOrPrivacyTemplate: FC<Props> = ({
         onClickLanguageButton={onClickLanguageButton}
         currentUrlPath={currentUrlPath}
       >
-        <Wrapper>
+        <_Wrapper>
           <MarkdownPageTitle text={createTitle(type, language)} />
           <LibraryBooks />
-          <ChildrenWrapper>{children}</ChildrenWrapper>
-        </Wrapper>
+          <_ChildrenWrapper>{children}</_ChildrenWrapper>
+        </_Wrapper>
       </ResponsiveLayout>
     </div>
   );

--- a/src/templates/TopTemplate/AppDescriptionArea.tsx
+++ b/src/templates/TopTemplate/AppDescriptionArea.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 import type { Language } from '../../types';
 import { assertNever } from '../../utils';
 
-const Wrapper = styled.div``;
+const _Wrapper = styled.div``;
 
 const textStyle = css`
   font-size: 14px;
@@ -15,12 +15,12 @@ const textStyle = css`
   text-align: center;
 `;
 
-const JaText = styled.div`
+const _JaText = styled.div`
   font-family: Zen Kaku Gothic New, sans-serif;
   ${textStyle};
 `;
 
-const EnText = styled.div`
+const _EnText = styled.div`
   font-family: Roboto, sans-serif;
   ${textStyle};
 `;
@@ -39,17 +39,17 @@ export type Props = {
 };
 
 const JaAppDescriptionArea: FC = () => (
-  <Wrapper>
-    <JaText>{jaUpperSectionText}</JaText>
-    <JaText>{jaLowerSectionText}</JaText>
-  </Wrapper>
+  <_Wrapper>
+    <_JaText>{jaUpperSectionText}</_JaText>
+    <_JaText>{jaLowerSectionText}</_JaText>
+  </_Wrapper>
 );
 
 const EnAppDescriptionArea: FC = () => (
-  <Wrapper>
-    <EnText>{enUpperSectionText}</EnText>
-    <EnText>{enLowerSectionText}</EnText>
-  </Wrapper>
+  <_Wrapper>
+    <_EnText>{enUpperSectionText}</_EnText>
+    <_EnText>{enLowerSectionText}</_EnText>
+  </_Wrapper>
 );
 
 export const AppDescriptionArea: FC<Props> = ({ language }) => {

--- a/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
+++ b/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
@@ -6,7 +6,7 @@ import {
   type CatRandomCopyButtonProps,
 } from '../../components';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   display: grid;
   gap: 20px;
   align-items: center;
@@ -21,11 +21,11 @@ export const CatRandomCopyButtonWrapper: FC<Props> = ({
   imageUrl,
   callback,
 }) => (
-  <Wrapper>
+  <_Wrapper>
     <CatRandomCopyButton
       appUrl={appUrl}
       imageUrl={imageUrl}
       callback={callback}
     />
-  </Wrapper>
+  </_Wrapper>
 );

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -22,7 +22,7 @@ import type { Language, CatImagesFetcher, LgtmImage } from '../../types';
 import { AppDescriptionArea } from './AppDescriptionArea';
 import { CatRandomCopyButtonWrapper } from './CatRandomCopyButtonWrapper';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   display: grid;
   grid-template-rows: auto 1fr auto;
   grid-template-columns: 100%;
@@ -119,7 +119,7 @@ export const TopTemplate: FC<Props> = ({
         onClickLanguageButton={onClickLanguageButton}
         currentUrlPath="/"
       >
-        <Wrapper>
+        <_Wrapper>
           <AppDescriptionArea language={language} />
           <CatRandomCopyButtonWrapper
             appUrl={appUrl}
@@ -144,7 +144,7 @@ export const TopTemplate: FC<Props> = ({
               callback={clipboardMarkdownCallback}
             />
           )}
-        </Wrapper>
+        </_Wrapper>
       </ResponsiveLayout>
     </div>
   );

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -7,7 +7,7 @@ import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
 import type { Language, ImageUploader, ImageValidator } from '../../types';
 
-const ImageWrapper = styled.div`
+const _ImageWrapper = styled.div`
   display: grid;
   grid-template-columns: 302px 302px 302px;
   @media (max-width: 767px) {
@@ -57,7 +57,7 @@ export const UploadTemplate: FC<Props> = ({
           onClickMarkdownSourceCopyButton={onClickMarkdownSourceCopyButton}
           appUrl={appUrl}
         />
-        <ImageWrapper>{catImage}</ImageWrapper>
+        <_ImageWrapper>{catImage}</_ImageWrapper>
       </ResponsiveLayout>
     </div>
   );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/205

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/205 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-ujfpojbvud.chromatic.com/

# 変更点概要

`styled-components` の `styled.div` などで生成されたComponentと通常のComponentの区別が分かりにくいので、`styled-components` で作られたComponentは `_` から命名するように変更。

これらをLinterでチェックする為 `eslint-plugin-styled-components-varname` を追加してESLintでチェック出来るようにした。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし