### PR TITLE
ねこ画像取得時にComponent全体が再レンダリングされてしまう現象を解消

### DIFF
--- a/src/templates/TopTemplate/LgtmImagesContents.tsx
+++ b/src/templates/TopTemplate/LgtmImagesContents.tsx
@@ -1,0 +1,82 @@
+import type { FC, ReactNode } from 'react';
+import styled from 'styled-components';
+import { useSnapshot } from 'valtio';
+import { ErrorContent, LgtmImages } from '../../components';
+import { CatButtonGroup } from '../../components/Button';
+import { AppUrl } from '../../constants';
+import { errorType } from '../../features';
+import { lgtmImageStateSelector } from '../../stores';
+import type { Language, LgtmImage } from '../../types';
+import { AppDescriptionArea } from './AppDescriptionArea';
+import { CatRandomCopyButtonWrapper } from './CatRandomCopyButtonWrapper';
+
+const _Wrapper = styled.div`
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 100%;
+  gap: 32px;
+`;
+
+type Props = {
+  language: Language;
+  lgtmImages: LgtmImage[];
+  errorCatImage: ReactNode;
+  onClickFetchRandomCatButton: () => Promise<void>;
+  onClickFetchNewArrivalCatButton: () => Promise<void>;
+  appUrl?: AppUrl;
+  clipboardMarkdownCallback?: () => void;
+  fetchRandomCatImagesCallback?: () => void;
+  fetchNewArrivalCatImagesCallback?: () => void;
+  catRandomCopyCallback?: () => void;
+};
+
+export const LgtmImagesContents: FC<Props> = ({
+  language,
+  lgtmImages,
+  errorCatImage,
+  onClickFetchRandomCatButton,
+  onClickFetchNewArrivalCatButton,
+  appUrl,
+  catRandomCopyCallback,
+  clipboardMarkdownCallback,
+}) => {
+  const snap = useSnapshot(lgtmImageStateSelector());
+
+  const fetchedLgtmImagesList = snap.lgtmImages ? snap.lgtmImages : lgtmImages;
+
+  const { isFailedFetchLgtmImages } = snap;
+
+  const { imageUrl } =
+    fetchedLgtmImagesList[
+      Math.floor(Math.random() * fetchedLgtmImagesList.length)
+    ];
+
+  return (
+    <_Wrapper>
+      <AppDescriptionArea language={language} />
+      <CatRandomCopyButtonWrapper
+        appUrl={appUrl}
+        imageUrl={imageUrl}
+        callback={catRandomCopyCallback}
+      />
+      <CatButtonGroup
+        onClickFetchRandomCatButton={onClickFetchRandomCatButton}
+        onClickFetchNewArrivalCatButton={onClickFetchNewArrivalCatButton}
+      />
+      {isFailedFetchLgtmImages === true ? (
+        <ErrorContent
+          type={errorType.internalServerError}
+          language={language}
+          catImage={errorCatImage}
+          shouldDisplayBackToTopButton={false}
+        />
+      ) : (
+        <LgtmImages
+          images={fetchedLgtmImagesList as LgtmImage[]}
+          appUrl={appUrl}
+          callback={clipboardMarkdownCallback}
+        />
+      )}
+    </_Wrapper>
+  );
+};

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -1,33 +1,14 @@
 import type { FC, ReactNode } from 'react';
-import styled from 'styled-components';
-import { useSnapshot } from 'valtio';
-
-import { ErrorContent, LgtmImages } from '../../components';
-import { CatButtonGroup } from '../../components/Button';
 import { AppUrl } from '../../constants';
 import {
-  errorType,
   NewArrivalCatImagesFetcherError,
   RandomCatImagesFetcherError,
 } from '../../features';
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
-import {
-  lgtmImageStateSelector,
-  updateIsFailedFetchLgtmImages,
-  updateLgtmImages,
-} from '../../stores';
-
+import { updateIsFailedFetchLgtmImages, updateLgtmImages } from '../../stores';
 import type { Language, CatImagesFetcher, LgtmImage } from '../../types';
-import { AppDescriptionArea } from './AppDescriptionArea';
-import { CatRandomCopyButtonWrapper } from './CatRandomCopyButtonWrapper';
-
-const _Wrapper = styled.div`
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  grid-template-columns: 100%;
-  gap: 32px;
-`;
+import { LgtmImagesContents } from './LgtmImagesContents';
 
 type Props = {
   language: Language;
@@ -57,8 +38,6 @@ export const TopTemplate: FC<Props> = ({
 }) => {
   const { isLanguageMenuDisplayed, onClickLanguageButton, onClickOutSideMenu } =
     useSwitchLanguage();
-
-  const snap = useSnapshot(lgtmImageStateSelector());
 
   const onClickFetchRandomCatButton = async () => {
     try {
@@ -102,15 +81,6 @@ export const TopTemplate: FC<Props> = ({
     }
   };
 
-  const fetchedLgtmImagesList = snap.lgtmImages ? snap.lgtmImages : lgtmImages;
-
-  const { isFailedFetchLgtmImages } = snap;
-
-  const { imageUrl } =
-    fetchedLgtmImagesList[
-      Math.floor(Math.random() * fetchedLgtmImagesList.length)
-    ];
-
   return (
     <div onClick={onClickOutSideMenu} aria-hidden="true">
       <ResponsiveLayout
@@ -119,32 +89,16 @@ export const TopTemplate: FC<Props> = ({
         onClickLanguageButton={onClickLanguageButton}
         currentUrlPath="/"
       >
-        <_Wrapper>
-          <AppDescriptionArea language={language} />
-          <CatRandomCopyButtonWrapper
-            appUrl={appUrl}
-            imageUrl={imageUrl}
-            callback={catRandomCopyCallback}
-          />
-          <CatButtonGroup
-            onClickFetchRandomCatButton={onClickFetchRandomCatButton}
-            onClickFetchNewArrivalCatButton={onClickFetchNewArrivalCatButton}
-          />
-          {isFailedFetchLgtmImages === true ? (
-            <ErrorContent
-              type={errorType.internalServerError}
-              language={language}
-              catImage={errorCatImage}
-              shouldDisplayBackToTopButton={false}
-            />
-          ) : (
-            <LgtmImages
-              images={fetchedLgtmImagesList as LgtmImage[]}
-              appUrl={appUrl}
-              callback={clipboardMarkdownCallback}
-            />
-          )}
-        </_Wrapper>
+        <LgtmImagesContents
+          language={language}
+          lgtmImages={lgtmImages}
+          errorCatImage={errorCatImage}
+          onClickFetchRandomCatButton={onClickFetchRandomCatButton}
+          onClickFetchNewArrivalCatButton={onClickFetchNewArrivalCatButton}
+          appUrl={appUrl}
+          catRandomCopyCallback={catRandomCopyCallback}
+          clipboardMarkdownCallback={clipboardMarkdownCallback}
+        />
       </ResponsiveLayout>
     </div>
   );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/201

# Done の定義

- ねこ画像取得時に `TopTemplate` 全体が再レンダリングされる現象が回避されている事

# スクリーンショット or Storybook の URL

## 少なくとも画面全体が再レンダリングされる現象回避出来ている

https://user-images.githubusercontent.com/11032365/195261038-887133c6-4034-4324-bca7-a978dd1f75f2.mov

# 変更点概要

`TopTemplate` 内の画像表示部分を別のComponentに分離する事で再レンダリングを回避するように変更。

本当はButtonの再レンダリングも防げるハズだが、調査に時間がかかりそうだったので、一旦今回の改修範囲にとどめた。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし