### PR TITLE
next/image の利用箇所を next/future/image を利用するように変更

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -25,6 +25,16 @@ const customViewports = {
   },
 };
 
+// https://github.com/RyanClementsHax/storybook-addon-next/issues/99#issuecomment-1247073410 に記載してある暫定対応を実施
+// https://github.com/RyanClementsHax/storybook-addon-next/pull/121 がマージされたら不要になるハズ
+import Image from 'next/future/image';
+
+const OriginalImage = Image.default;
+Object.defineProperty(Image, 'default', {
+  configurable: true,
+  value: (props) => <OriginalImage {...props} unoptimized />,
+});
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/src/README.md
+++ b/src/README.md
@@ -43,7 +43,7 @@ Component の内部で React hooks を利用する事は問題ありません。
 
 また Component は `styled-components` で作成しているので、`styled-components` にも依存しています。
 
-一部 `next/image` に依存しているものも存在します。
+一部 `next/future/image` に依存しているものも存在します。
 
 Component 名と同様のディレクトリ名を作成して `index.ts` を使って外部公開が必要な Component だけを export するようにします。
 

--- a/src/components/ErrorContent/ErrorContent.stories.tsx
+++ b/src/components/ErrorContent/ErrorContent.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentStoryObj } from '@storybook/react';
-import Image from 'next/image';
+import Image from 'next/future/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
 import notFound from '../../images/not_found.webp';
@@ -20,8 +20,9 @@ const NotFoundImage = () => (
   <Image
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     src={notFoundSrc}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="404 Not Found"
     priority={true}
   />
@@ -34,8 +35,9 @@ const InternalServerErrorImage = () => (
   <Image
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     src={internalServerErrorSrc}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="500 Internal Server Error"
     priority={true}
   />
@@ -48,8 +50,9 @@ const ServiceUnavailableImage = () => (
   <Image
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     src={serviceUnavailableSrc}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="503 Service Unavailable"
     priority={true}
   />

--- a/src/components/LgtmImages/LgtmImageContent.tsx
+++ b/src/components/LgtmImages/LgtmImageContent.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import Image from 'next/image';
+import Image from 'next/future/image';
 import styled from 'styled-components';
 
 import { AppUrl, defaultAppUrl } from '../../constants';
@@ -40,8 +40,9 @@ export const LgtmImageContent: FC<Props> = ({
     <_Wrapper key={id} ref={imageContextRef}>
       <Image
         src={imageUrl}
-        layout="fill"
-        objectFit="contain"
+        style={{ objectFit: 'contain' }}
+        sizes="100vw"
+        fill
         alt="lgtm-cat-image"
         priority={true}
       />

--- a/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentStoryObj } from '@storybook/react';
-import Image from 'next/image';
+import Image from 'next/future/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
 import notFound from '../../images/not_found.webp';
@@ -20,8 +20,9 @@ const NotFoundImage = () => (
   <Image
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     src={notFoundSrc}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="404 Not Found"
     priority={true}
   />
@@ -34,8 +35,9 @@ const InternalServerErrorImage = () => (
   <Image
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     src={internalServerErrorSrc}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="500 Internal Server Error"
     priority={true}
   />
@@ -48,8 +50,9 @@ const ServiceUnavailableImage = () => (
   <Image
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     src={serviceUnavailableSrc}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="503 Service Unavailable"
     priority={true}
   />

--- a/src/templates/TopTemplate/TopTemplate.stories.tsx
+++ b/src/templates/TopTemplate/TopTemplate.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentStoryObj } from '@storybook/react';
-import Image from 'next/image';
+import Image from 'next/future/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
 
@@ -199,8 +199,9 @@ const InternalServerErrorImage = () => (
   <Image
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
     src={internalServerError.src}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="500 Internal Server Error"
     priority={true}
   />

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { ComponentStoryObj } from '@storybook/react';
-import Image from 'next/image';
+import Image from 'next/future/image';
 
 import { createSuccessResult } from '../../features';
 import type {
@@ -16,7 +16,7 @@ import { UploadTemplate } from '.';
 
 const CatImage = () => (
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-  <Image src={cat.src} width="302px" height="302px" alt="Cat" priority={true} />
+  <Image src={cat.src} alt="Cat" width={302} height={302} priority={true} />
 );
 
 const imageValidator: ImageValidator = async (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         'react-dom',
         'styled-components',
         'next/link',
-        'next/image',
+        'next/future/image',
       ],
       output: {
         globals: {
@@ -27,7 +27,7 @@ export default defineConfig({
           'react-dom': 'ReactDOM',
           'styled-components': 'styled',
           'next/link': 'Link',
-          'next/image': 'Image',
+          'next/future/image': 'Image',
         },
       },
     },


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/68

# Done の定義

- `next/image` の利用箇所が `next/future/image` を利用するように変更されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-xcpzhhwwdr.chromatic.com/

# 変更点概要

`next/image` の利用箇所を `next/future/image` を利用するように変更。

当初は `LgtmImages` Componentだけを試験的に置き換えるつもりだったが、`next/image` と混合していると `vite.config.ts` の設定が面倒なので全て `next/future/image` を利用するように変更。

`storybook-addon-next` が `next/future/image` に対応していないので、`.storybook/preview.js` にパッチを当てる事で対応。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

修正内容に関しては公式の https://nextjs.org/docs/api-reference/next/future/image を参照。

- `layout="fill"` → `sizes="100vw" fill`
- `objectFit="contain"` → `style={{ objectFit: 'contain' }}`