### PR TITLE
Build結果からbackgroundイメージが消えてしまうので渡し方を変更

### DIFF
--- a/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
+++ b/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.tsx
@@ -10,7 +10,7 @@ import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdo
 import slash from '../images/slash.png';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-const slashSrc = slash.src;
+const slashSrc = slash;
 
 const _Button = styled.button`
   ${mixins.buttonBase};

--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -8,7 +8,7 @@ import type { CustomDataAttrGtmClick } from '../../../types';
 import slash from '../images/slash.png';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-const slashSrc = slash.src;
+const slashSrc = slash;
 
 const _Span = styled.span`
   background: ${mixins.colors.primary} url(${slashSrc}) repeat 0 0/16px auto;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/219

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/219 の現象が解消されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-yofufxcaav.chromatic.com/?path=/story/components-button-catbuttongroup--default

# 変更点概要

以下のように `background` にはイメージ.srcで値を渡していたが、これだとStorybook上では表示されるがBuild時にbackgroundイメージが消えてしまう。

```
import slash from '../images/slash.png';

const slashSrc = slash.src;
```

なので以下のようにイメージをそのまま渡すように変更。

```
import slash from '../images/slash.png';

// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
const slashSrc = slash;

const _Button = styled.button`
  ${mixins.buttonBase};
  width: 227px;
  background: ${mixins.colors.primary} url(${slashSrc}) repeat 0 0/16px auto;
`;
```

副作用としてStorybookでは表示されなくなってしまった:sweat_drops:

こちらの原因は不明だが、本番で表示されないほうが問題があるので一旦は割り切る事にする。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

# 補足情報

特になし