### PR TITLE
StorybookのViewportに実際に使われているスマホのサイズを追加

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,13 @@ import 'ress/ress.css';
 import './markdown.css';
 
 const customViewports = {
+  iPhone11ProMax: {
+    name: 'iPhone 11 Pro Max',
+    styles: {
+      width: '414px',
+      height: '896px',
+    },
+  },
   iPhone12: {
     name: 'iPhone 12 Pro',
     styles: {
@@ -9,11 +16,39 @@ const customViewports = {
       height: '844px',
     },
   },
-  GooglePixel: {
+  iPhone13ProMax: {
+    name: 'iPhone 13 Pro Max',
+    styles: {
+      width: '428px',
+      height: '926px',
+    },
+  },
+  googlePixel3: {
     name: 'Google Pixel 3',
     styles: {
       width: '411px',
       height: '823px',
+    },
+  },
+  googlePixel5: {
+    name: 'Google Pixel 5',
+    styles: {
+      width: '393px',
+      height: '851px',
+    },
+  },
+  iPadMini: {
+    name: 'iPad mini 2〜5',
+    styles: {
+      width: '768px',
+      height: '1024px',
+    },
+  },
+  iPadMini6: {
+    name: 'iPad mini 6',
+    styles: {
+      width: '744px',
+      height: '1133px',
     },
   },
   iPadPro11: {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/212

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/212 のDoneの定義を満たしている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-cuyffeubnz.chromatic.com/

# 変更点概要

表題の通り。

メインユーザーがエンジニアでPCからの利用がメインなので狭い幅のスマホまでデザインでカバーする必要性が薄いので、横幅が `375px` 未満の機種は追加していない。

# レビュアーに重点的にチェックして欲しい点

追加したデバイスに関して、他にも追加したほうが良い物があれば教えてもらえると:pray:

# 補足情報

特になし