### PR TITLE
next/linkの仕様が変わったのでスタイルを変更

### DIFF
--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -15,7 +15,7 @@ const _Span = styled.span`
   ${mixins.buttonBase};
 `;
 
-const _Text = styled.div`
+const _Text = styled.a`
   ${mixins.buttonText};
 `;
 
@@ -39,7 +39,7 @@ export const UploadCatButton: FC<Props> = ({
   link,
   customDataAttrGtmClick,
 }) => (
-  <Link href={link} prefetch={false}>
+  <Link href={link} prefetch={false} passHref={true}>
     <_Span data-gtm-click={customDataAttrGtmClick}>
       <FaCloudUploadAlt
         style={faCloudUploadAltStyle}

--- a/src/components/ErrorContent/BackToTopButton.tsx
+++ b/src/components/ErrorContent/BackToTopButton.tsx
@@ -20,7 +20,7 @@ const _Span = styled.span`
   }
 `;
 
-const _Text = styled.div`
+const _Text = styled.a`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -61,7 +61,7 @@ type Props = {
 };
 
 export const BackToTopButton: FC<Props> = ({ language }) => (
-  <Link href="/" prefetch={false}>
+  <Link href="/" prefetch={false} passHref={true}>
     <_Span>
       <_Text>{createBackToTopPageText(language)}</_Text>
     </_Span>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -117,14 +117,14 @@ export const Footer: FC<Props> = ({ language }) => {
   return (
     <_Wrapper>
       <_UpperSection>
-        <Link href={terms.link} prefetch={false}>
+        <Link href={terms.link} prefetch={false} passHref={true}>
           <_TermsLinkText data-gtm-click="footer-terms-link">
             {terms.text}
           </_TermsLinkText>
         </Link>
         {/* eslint-disable no-irregular-whitespace */}
         <_SeparatorText> / </_SeparatorText>
-        <Link href={privacy.link} prefetch={false}>
+        <Link href={privacy.link} prefetch={false} passHref={true}>
           <_PrivacyLinkText data-gtm-click="footer-privacy-link">
             {privacy.text}
           </_PrivacyLinkText>

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -116,13 +116,13 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
       </_HeaderWrapper>
       <_LinkGroupWrapper>
         <_LinkWrapper>
-          <Link href="/" prefetch={false}>
+          <Link href="/" prefetch={false} passHref={true}>
             <_LinkText data-gtm-click="global-menu-top-link">TOP</_LinkText>
           </Link>
           <_UnderLine />
         </_LinkWrapper>
         <_LinkWrapper>
-          <Link href="/upload" prefetch={false}>
+          <Link href="/upload" prefetch={false} passHref={true}>
             <_LinkText data-gtm-click="global-menu-upload-cat-link">
               <FaCloudUploadAlt style={faCloudUploadAltStyle} />
               Upload new Cats
@@ -131,7 +131,7 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
           <_UnderLine />
         </_LinkWrapper>
         <_LinkWrapper>
-          <Link href={termsOfUseLinks.link} prefetch={false}>
+          <Link href={termsOfUseLinks.link} prefetch={false} passHref={true}>
             <_LinkText data-gtm-click="global-menu-terms-link">
               {termsOfUseLinks.text}
             </_LinkText>
@@ -139,7 +139,7 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
           <_UnderLine />
         </_LinkWrapper>
         <_LinkWrapper>
-          <Link href={privacyPolicyLinks.link} prefetch={false}>
+          <Link href={privacyPolicyLinks.link} prefetch={false} passHref={true}>
             <_LinkText data-gtm-click="global-menu-terms-link">
               {privacyPolicyLinks.text}
             </_LinkText>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -100,7 +100,7 @@ export const Header: FC<Props> = ({
       <_Wrapper>
         <_Header>
           <FaBars style={faBarsStyle} onClick={openMenu} />
-          <Link href="/" prefetch={false}>
+          <Link href="/" prefetch={false} passHref={true}>
             <_Title data-gtm-click="header-app-title">LGTMeow</_Title>
           </Link>
           <LanguageButton onClick={onClickLanguageButton} />

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -35,6 +35,7 @@ const _Title = styled.a`
   line-height: 28px;
   color: #000;
   text-align: center;
+  text-decoration: none;
   cursor: pointer;
   transform: translateX(-50%);
 `;

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -103,7 +103,7 @@ export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
     </_EnTextWrapper>
     <_Separator />
     <_JaTextWrapper>
-      <Link href={currentUrlPath} locale="ja" prefetch={false}>
+      <Link href={currentUrlPath} locale="ja" prefetch={false} passHref={true}>
         <_JaText data-gtm-click="language-menu-ja-link">
           {language === 'ja' ? <FaAngleRight /> : ''}
           日本語

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -79,6 +79,7 @@ const _JaText = styled.a`
   line-height: 19px;
   color: ${mixins.colors.background};
   text-align: center;
+  text-decoration: none;
   cursor: pointer;
 `;
 

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -69,7 +69,11 @@ export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
       return (
         <_PrivacyPolicyArea>
           アップロードするボタンを押下することで{' '}
-          <Link href={privacyLinkAttribute.link} prefetch={false}>
+          <Link
+            href={privacyLinkAttribute.link}
+            prefetch={false}
+            passHref={true}
+          >
             <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
           </Link>{' '}
           に同意したと見なします
@@ -79,7 +83,11 @@ export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
       return (
         <_PrivacyPolicyArea>
           By pressing the upload button, you agree to the{' '}
-          <Link href={privacyLinkAttribute.link} prefetch={false}>
+          <Link
+            href={privacyLinkAttribute.link}
+            prefetch={false}
+            passHref={true}
+          >
             <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
           </Link>{' '}
           .


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/223

# Done の定義

- next/linkに `passHref` が渡されるようになっている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-iaoarmbfmv.chromatic.com/

# 変更点概要

デザインが崩れてHydration Errorが発生してしまうので `passHref` を `true` に設定してみた。

またこれによって<a> の下線がデザイン上意図しない箇所に表示されるようになってしまったのでCSSも調整している。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
