### PR TITLE
デザイン崩れが発生している箇所にlegacyBehaviorを設定

### DIFF
--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -39,7 +39,7 @@ export const UploadCatButton: FC<Props> = ({
   link,
   customDataAttrGtmClick,
 }) => (
-  <Link href={link} prefetch={false} passHref={true}>
+  <Link href={link} prefetch={false} passHref={true} legacyBehavior={true}>
     <_Span data-gtm-click={customDataAttrGtmClick}>
       <FaCloudUploadAlt
         style={faCloudUploadAltStyle}

--- a/src/components/ErrorContent/BackToTopButton.tsx
+++ b/src/components/ErrorContent/BackToTopButton.tsx
@@ -61,7 +61,7 @@ type Props = {
 };
 
 export const BackToTopButton: FC<Props> = ({ language }) => (
-  <Link href="/" prefetch={false} passHref={true}>
+  <Link href="/" prefetch={false} passHref={true} legacyBehavior={true}>
     <_Span>
       <_Text>{createBackToTopPageText(language)}</_Text>
     </_Span>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -117,14 +117,24 @@ export const Footer: FC<Props> = ({ language }) => {
   return (
     <_Wrapper>
       <_UpperSection>
-        <Link href={terms.link} prefetch={false} passHref={true}>
+        <Link
+          href={terms.link}
+          prefetch={false}
+          passHref={true}
+          legacyBehavior={true}
+        >
           <_TermsLinkText data-gtm-click="footer-terms-link">
             {terms.text}
           </_TermsLinkText>
         </Link>
         {/* eslint-disable no-irregular-whitespace */}
         <_SeparatorText> / </_SeparatorText>
-        <Link href={privacy.link} prefetch={false} passHref={true}>
+        <Link
+          href={privacy.link}
+          prefetch={false}
+          passHref={true}
+          legacyBehavior={true}
+        >
           <_PrivacyLinkText data-gtm-click="footer-privacy-link">
             {privacy.text}
           </_PrivacyLinkText>

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -91,7 +91,12 @@ export type Props = {
 export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
   <_Wrapper>
     <_EnTextWrapper>
-      <Link href={currentUrlPath} locale="en" prefetch={false}>
+      <Link
+        href={currentUrlPath}
+        locale="en"
+        prefetch={false}
+        legacyBehavior={true}
+      >
         <_EnText data-gtm-click="language-menu-en-link">
           {language === 'en' ? <FaAngleRight /> : ''}
           English
@@ -104,7 +109,13 @@ export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
     </_EnTextWrapper>
     <_Separator />
     <_JaTextWrapper>
-      <Link href={currentUrlPath} locale="ja" prefetch={false} passHref={true}>
+      <Link
+        href={currentUrlPath}
+        locale="ja"
+        prefetch={false}
+        passHref={true}
+        legacyBehavior={true}
+      >
         <_JaText data-gtm-click="language-menu-ja-link">
           {language === 'ja' ? <FaAngleRight /> : ''}
           日本語


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/223

# Done の定義

- デザイン崩れの発生箇所にlegacyBehaviorが追加されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-rrifubrdiv.chromatic.com/

# 変更点概要

Next.js 13からNextLinkの配下に `<a>` が不要になったがこれが原因でデザインが崩れているように見えるので以下を参考に `legacyBehavior` を追加。

これで以前の挙動に戻るのでデザイン崩れも解消されるハズ。

https://nextjs.org/docs/api-reference/next/link

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし