### PR TITLE
全ての next/link にlegacyBehaviorとpassHrefを追加

### DIFF
--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -116,13 +116,18 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
       </_HeaderWrapper>
       <_LinkGroupWrapper>
         <_LinkWrapper>
-          <Link href="/" prefetch={false} passHref={true}>
+          <Link href="/" prefetch={false} passHref={true} legacyBehavior={true}>
             <_LinkText data-gtm-click="global-menu-top-link">TOP</_LinkText>
           </Link>
           <_UnderLine />
         </_LinkWrapper>
         <_LinkWrapper>
-          <Link href="/upload" prefetch={false} passHref={true}>
+          <Link
+            href="/upload"
+            prefetch={false}
+            passHref={true}
+            legacyBehavior={true}
+          >
             <_LinkText data-gtm-click="global-menu-upload-cat-link">
               <FaCloudUploadAlt style={faCloudUploadAltStyle} />
               Upload new Cats
@@ -131,7 +136,12 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
           <_UnderLine />
         </_LinkWrapper>
         <_LinkWrapper>
-          <Link href={termsOfUseLinks.link} prefetch={false} passHref={true}>
+          <Link
+            href={termsOfUseLinks.link}
+            prefetch={false}
+            passHref={true}
+            legacyBehavior={true}
+          >
             <_LinkText data-gtm-click="global-menu-terms-link">
               {termsOfUseLinks.text}
             </_LinkText>
@@ -139,7 +149,12 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
           <_UnderLine />
         </_LinkWrapper>
         <_LinkWrapper>
-          <Link href={privacyPolicyLinks.link} prefetch={false} passHref={true}>
+          <Link
+            href={privacyPolicyLinks.link}
+            prefetch={false}
+            passHref={true}
+            legacyBehavior={true}
+          >
             <_LinkText data-gtm-click="global-menu-terms-link">
               {privacyPolicyLinks.text}
             </_LinkText>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -101,7 +101,7 @@ export const Header: FC<Props> = ({
       <_Wrapper>
         <_Header>
           <FaBars style={faBarsStyle} onClick={openMenu} />
-          <Link href="/" prefetch={false} passHref={true}>
+          <Link href="/" prefetch={false} passHref={true} legacyBehavior={true}>
             <_Title data-gtm-click="header-app-title">LGTMeow</_Title>
           </Link>
           <LanguageButton onClick={onClickLanguageButton} />

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -73,6 +73,7 @@ export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
             href={privacyLinkAttribute.link}
             prefetch={false}
             passHref={true}
+            legacyBehavior={true}
           >
             <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
           </Link>{' '}
@@ -87,6 +88,7 @@ export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
             href={privacyLinkAttribute.link}
             prefetch={false}
             passHref={true}
+            legacyBehavior={true}
           >
             <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
           </Link>{' '}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/223

# Done の定義

- next/link にlegacyBehaviorとpassHrefが追加されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-wfeceogxko.chromatic.com/

# 変更点概要

デザイン崩れが発生していない箇所は `legacyBehavior` の設定は行っていなかったが、Hydration Errorが発生するので以下を参考に一律で設定するように変更。

https://nextjs.org/docs/api-reference/next/link

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
