### PR TITLE
next/link の legacyBehavior を利用しない形に改修

### DIFF
--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -15,7 +15,7 @@ const _Span = styled.span`
   ${mixins.buttonBase};
 `;
 
-const _Text = styled.div`
+const _Text = styled.span`
   ${mixins.buttonText};
 `;
 

--- a/src/components/Button/UploadCatButton/UploadCatButton.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.tsx
@@ -15,7 +15,7 @@ const _Span = styled.span`
   ${mixins.buttonBase};
 `;
 
-const _Text = styled.a`
+const _Text = styled.div`
   ${mixins.buttonText};
 `;
 
@@ -39,7 +39,7 @@ export const UploadCatButton: FC<Props> = ({
   link,
   customDataAttrGtmClick,
 }) => (
-  <Link href={link} prefetch={false} passHref={true} legacyBehavior={true}>
+  <Link href={link} prefetch={false} style={{ textDecoration: 'none' }}>
     <_Span data-gtm-click={customDataAttrGtmClick}>
       <FaCloudUploadAlt
         style={faCloudUploadAltStyle}

--- a/src/components/ErrorContent/BackToTopButton.tsx
+++ b/src/components/ErrorContent/BackToTopButton.tsx
@@ -20,7 +20,7 @@ const _Span = styled.span`
   }
 `;
 
-const _Text = styled.a`
+const _Text = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -61,7 +61,7 @@ type Props = {
 };
 
 export const BackToTopButton: FC<Props> = ({ language }) => (
-  <Link href="/" prefetch={false} passHref={true} legacyBehavior={true}>
+  <Link href="/" prefetch={false} style={{ textDecoration: 'none' }}>
     <_Span>
       <_Text>{createBackToTopPageText(language)}</_Text>
     </_Span>

--- a/src/components/ErrorContent/BackToTopButton.tsx
+++ b/src/components/ErrorContent/BackToTopButton.tsx
@@ -20,7 +20,7 @@ const _Span = styled.span`
   }
 `;
 
-const _Text = styled.div`
+const _Text = styled.span`
   flex: none;
   flex-grow: 0;
   order: 0;

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, CSSProperties } from 'react';
 import Link from 'next/link';
 import styled from 'styled-components';
 import {
@@ -6,7 +6,6 @@ import {
   createTermsOfUseLinksFromLanguages,
 } from '../../features';
 import { mixins } from '../../styles';
-
 import type { Language } from '../../types';
 
 const _Wrapper = styled.div`
@@ -28,38 +27,6 @@ const _UpperSection = styled.div`
   width: 100%;
   padding: 10px 0 20px;
   background: ${mixins.colors.subVariant};
-`;
-
-const _TermsLinkText = styled.a`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  height: 28px;
-  font-family: Roboto, sans-serif;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 28px;
-  color: #43281e;
-  text-align: center;
-  text-decoration-line: underline;
-  cursor: pointer;
-`;
-
-const _PrivacyLinkText = styled.a`
-  flex: none;
-  flex-grow: 0;
-  order: 2;
-  height: 28px;
-  font-family: Roboto, sans-serif;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 28px;
-  color: #43281e;
-  text-align: center;
-  text-decoration-line: underline;
-  cursor: pointer;
 `;
 
 const _SeparatorText = styled.div`
@@ -105,6 +72,38 @@ const _LowerSectionText = styled.div`
   color: #43281e;
 `;
 
+const termsLinkTextStyle: CSSProperties = {
+  flex: 'none',
+  flexGrow: '0',
+  order: '0',
+  height: '28px',
+  fontFamily: 'Roboto, sans-serif',
+  fontSize: '14px',
+  fontStyle: 'normal',
+  fontWeight: '400',
+  lineHeight: '28px',
+  color: '#43281e',
+  textAlign: 'center',
+  textDecorationLine: 'underline',
+  cursor: 'pointer',
+};
+
+const privacyLinkTextStyle: CSSProperties = {
+  flex: 'none',
+  flexGrow: '0',
+  order: '2',
+  height: '28px',
+  fontFamily: 'Roboto, sans-serif',
+  fontSize: '14px',
+  fontStyle: 'normal',
+  fontWeight: '400',
+  lineHeight: '28px',
+  color: '#43281e',
+  textAlign: 'center',
+  textDecorationLine: 'underline',
+  cursor: 'pointer',
+};
+
 export type Props = {
   language: Language;
 };
@@ -117,27 +116,13 @@ export const Footer: FC<Props> = ({ language }) => {
   return (
     <_Wrapper>
       <_UpperSection>
-        <Link
-          href={terms.link}
-          prefetch={false}
-          passHref={true}
-          legacyBehavior={true}
-        >
-          <_TermsLinkText data-gtm-click="footer-terms-link">
-            {terms.text}
-          </_TermsLinkText>
+        <Link href={terms.link} prefetch={false} style={termsLinkTextStyle}>
+          <p data-gtm-click="footer-terms-link">{terms.text}</p>
         </Link>
         {/* eslint-disable no-irregular-whitespace */}
         <_SeparatorText> / </_SeparatorText>
-        <Link
-          href={privacy.link}
-          prefetch={false}
-          passHref={true}
-          legacyBehavior={true}
-        >
-          <_PrivacyLinkText data-gtm-click="footer-privacy-link">
-            {privacy.text}
-          </_PrivacyLinkText>
+        <Link href={privacy.link} prefetch={false} style={privacyLinkTextStyle}>
+          <p data-gtm-click="footer-privacy-link">{privacy.text}</p>
         </Link>
       </_UpperSection>
       <_LowerSection>

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -68,7 +68,7 @@ const _LinkWrapper = styled.div`
   height: 45px;
 `;
 
-const _LinkText = styled.div`
+const _LinkText = styled.span`
   display: flex;
   align-items: center;
   font-family: Roboto, sans-serif;

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -116,7 +116,7 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
       </_HeaderWrapper>
       <_LinkGroupWrapper>
         <_LinkWrapper>
-          <Link href="/" prefetch={false} passHref={true} legacyBehavior={true}>
+          <Link href="/" prefetch={false}>
             <_LinkText data-gtm-click="global-menu-top-link">TOP</_LinkText>
           </Link>
           <_UnderLine />

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -68,7 +68,7 @@ const _LinkWrapper = styled.div`
   height: 45px;
 `;
 
-const _LinkText = styled.a`
+const _LinkText = styled.div`
   display: flex;
   align-items: center;
   font-family: Roboto, sans-serif;
@@ -122,12 +122,7 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
           <_UnderLine />
         </_LinkWrapper>
         <_LinkWrapper>
-          <Link
-            href="/upload"
-            prefetch={false}
-            passHref={true}
-            legacyBehavior={true}
-          >
+          <Link href="/upload" prefetch={false}>
             <_LinkText data-gtm-click="global-menu-upload-cat-link">
               <FaCloudUploadAlt style={faCloudUploadAltStyle} />
               Upload new Cats
@@ -136,12 +131,7 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
           <_UnderLine />
         </_LinkWrapper>
         <_LinkWrapper>
-          <Link
-            href={termsOfUseLinks.link}
-            prefetch={false}
-            passHref={true}
-            legacyBehavior={true}
-          >
+          <Link href={termsOfUseLinks.link} prefetch={false}>
             <_LinkText data-gtm-click="global-menu-terms-link">
               {termsOfUseLinks.text}
             </_LinkText>
@@ -149,12 +139,7 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
           <_UnderLine />
         </_LinkWrapper>
         <_LinkWrapper>
-          <Link
-            href={privacyPolicyLinks.link}
-            prefetch={false}
-            passHref={true}
-            legacyBehavior={true}
-          >
+          <Link href={privacyPolicyLinks.link} prefetch={false}>
             <_LinkText data-gtm-click="global-menu-terms-link">
               {privacyPolicyLinks.text}
             </_LinkText>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -23,7 +23,7 @@ const _Header = styled.div`
   margin: 0 auto;
 `;
 
-const _Title = styled.a`
+const _Title = styled.div`
   position: absolute;
   top: 26.67%;
   bottom: 26.67%;
@@ -101,7 +101,7 @@ export const Header: FC<Props> = ({
       <_Wrapper>
         <_Header>
           <FaBars style={faBarsStyle} onClick={openMenu} />
-          <Link href="/" prefetch={false} passHref={true} legacyBehavior={true}>
+          <Link href="/" prefetch={false}>
             <_Title data-gtm-click="header-app-title">LGTMeow</_Title>
           </Link>
           <LanguageButton onClick={onClickLanguageButton} />

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -23,7 +23,7 @@ const _Header = styled.div`
   margin: 0 auto;
 `;
 
-const _Title = styled.div`
+const _Title = styled.span`
   position: absolute;
   top: 26.67%;
   bottom: 26.67%;

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -36,7 +36,7 @@ const _EnTextWrapper = styled.span`
   order: 0;
 `;
 
-const _EnText = styled.a`
+const _EnText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -66,7 +66,7 @@ const _JaTextWrapper = styled.span`
   order: 2;
 `;
 
-const _JaText = styled.a`
+const _JaText = styled.div`
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -94,8 +94,7 @@ export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
       <Link
         href={currentUrlPath}
         locale="en"
-        prefetch={false}
-        legacyBehavior={true}
+        style={{ textDecoration: 'none' }}
       >
         <_EnText data-gtm-click="language-menu-en-link">
           {language === 'en' ? <FaAngleRight /> : ''}
@@ -113,8 +112,7 @@ export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
         href={currentUrlPath}
         locale="ja"
         prefetch={false}
-        passHref={true}
-        legacyBehavior={true}
+        style={{ textDecoration: 'none' }}
       >
         <_JaText data-gtm-click="language-menu-ja-link">
           {language === 'ja' ? <FaAngleRight /> : ''}

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -36,7 +36,8 @@ const _EnTextWrapper = styled.span`
   order: 0;
 `;
 
-const _EnText = styled.div`
+const _EnText = styled.span`
+  display: block;
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -66,7 +67,8 @@ const _JaTextWrapper = styled.span`
   order: 2;
 `;
 
-const _JaText = styled.div`
+const _JaText = styled.span`
+  display: block;
   flex: none;
   flex-grow: 0;
   order: 0;

--- a/src/components/Upload/UploadForm/StyledComponents.tsx
+++ b/src/components/Upload/UploadForm/StyledComponents.tsx
@@ -127,7 +127,7 @@ export const _PrivacyPolicyArea = styled.div`
   text-align: center;
 `;
 
-export const _PrivacyLinkText = styled.a`
+export const _PrivacyLinkText = styled.span`
   height: 42px;
   font-family: Roboto, sans-serif;
   font-size: 12px;

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -69,12 +69,7 @@ export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
       return (
         <_PrivacyPolicyArea>
           アップロードするボタンを押下することで{' '}
-          <Link
-            href={privacyLinkAttribute.link}
-            prefetch={false}
-            passHref={true}
-            legacyBehavior={true}
-          >
+          <Link href={privacyLinkAttribute.link} prefetch={false}>
             <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
           </Link>{' '}
           に同意したと見なします
@@ -84,12 +79,7 @@ export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
       return (
         <_PrivacyPolicyArea>
           By pressing the upload button, you agree to the{' '}
-          <Link
-            href={privacyLinkAttribute.link}
-            prefetch={false}
-            passHref={true}
-            legacyBehavior={true}
-          >
+          <Link href={privacyLinkAttribute.link} prefetch={false}>
             <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
           </Link>{' '}
           .


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/234

# Done の定義

- `legacyBehavior` を利用しない形に修正されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-nnohcjtrde.chromatic.com/

# 変更点概要

今後おそらく廃止される予定の `next/link` の `legacyBehavior` を利用している箇所を利用しない形に変更。

元々Next.js 13からの `next/link` は配下に <a> タグがなくても <a> タグで要素をラップする仕様だったが当初バージョンアップ時にデザインが崩れてしまい、かつStorybook上での表示確認も出来ない状態だった。

しかしStorybookのほうで確認が出来るようになったので今回 `legacyBehavior` の利用箇所を全て削除。

元々 <a> タグを利用していた箇所は <span> タグで表現するように統一した。

# レビュアーに重点的にチェックして欲しい点

元々 <a> タグを利用していた箇所は <span> タグで表現するように統一したけど、このあたりの書き方に問題がないか確認してもらえると:pray:

# 補足情報

特になし