### PR TITLE
TypeScriptのtargetをes2016に変更

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2016",
     "module": "esnext",
     "jsx": "react-jsxdev",
     "sourceMap": true,


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/240

# Done の定義

- TypeScript の`compilerOptions.target` が `es2016` に変更されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-oydgxxnejf.chromatic.com/

# 変更点概要

ViteのReact用プラグインを `@vitejs/plugin-react` に戻したが、https://github.com/nekochans/lgtm-cat-ui/pull/243 で起こったエラーが再度発生してしまうので `compilerOptions.target` をes2016に変更してみる。

これで解消しなかった場合、Viteのバージョンを一旦3系に戻す対応を行う。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし