### PR TITLE
ESModule 形式のみアプトプットするように変更

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       name: 'lgtm-cat-ui',
-      formats: ['es', 'umd'],
+      formats: ['es'],
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/240

# Done の定義

- 出力されているjsファイルがESModuleのみに変更されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-vfkcujjfxw.chromatic.com/

# 変更点概要

https://github.com/nekochans/lgtm-cat-ui/pull/243 のエラーは `umd` 形式のファイルでエラーが発生していたので、ESModuleのファイルだけ出力するように変更。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし