### PR TITLE
umd形式のファイルは生成しないようになったので package.json を変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,11 @@
   "name": "@nekochans/lgtm-cat-ui",
   "version": "2.2.6",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
-  "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "main": "./dist/index.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
+      "import": "./dist/index.es.js"
     }
   },
   "files": [


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/240

# Done の定義

- umd形式のファイルが `package.json` から削除されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-clnxwsclyu.chromatic.com/

# 変更点概要

https://github.com/nekochans/lgtm-cat-ui/pull/247 でumd形式のファイルを出力しないようにしたので `package.json` から設定を削除。

`main` と `exports` は両方設定しても `exports` が優先されるが、両方設定する事が推奨されるようなので `main` には `./dist/index.es.js` を設定してある。

https://zenn.dev/makotot/articles/5edb504ef7d2e6

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし