### PR TITLE
Form側で画像サイズのバリデーション処理を実装

### DIFF
--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -15,6 +15,7 @@ import {
   extractImageExtFromValidFileType,
   createPrivacyPolicyLinksFromLanguages,
 } from '../../../features';
+import { isAcceptableFileSize } from '../../../features/lgtmImage';
 import { mixins } from '../../../styles';
 import type {
   AcceptedTypesImageExtension,
@@ -47,6 +48,7 @@ import {
 } from './StyledComponents';
 import {
   cautionText,
+  createImageSizeTooLargeErrorMessage,
   createNotAllowedImageExtensionErrorMessage,
   imageDropAreaText,
   noteList,
@@ -170,6 +172,13 @@ export const UploadForm: FC<Props> = ({
       setDisplayErrorMessages(
         createNotAllowedImageExtensionErrorMessage(fileType, language)
       );
+      stateInitAtError();
+
+      return;
+    }
+
+    if (!isAcceptableFileSize(file)) {
+      setDisplayErrorMessages(createImageSizeTooLargeErrorMessage(language));
       stateInitAtError();
 
       return;

--- a/src/components/Upload/UploadForm/i18n.ts
+++ b/src/components/Upload/UploadForm/i18n.ts
@@ -1,3 +1,4 @@
+import { acceptableImageSizeThresholdText } from '../../../features/lgtmImage';
 import type { Language } from '../../../types';
 import { assertNever } from '../../../utils';
 
@@ -69,6 +70,25 @@ export const createNotAllowedImageExtensionErrorMessage = (
       return [
         `${fileType} is not allowed.`,
         'Only png, jpg, jpeg images can be uploaded.',
+      ];
+    default:
+      return assertNever(language);
+  }
+};
+
+export const createImageSizeTooLargeErrorMessage = (
+  language: Language
+): string[] => {
+  switch (language) {
+    case 'ja':
+      return [
+        '画像サイズが大きすぎます。',
+        `お手数ですが${acceptableImageSizeThresholdText}以下の画像を利用して下さい。`,
+      ];
+    case 'en':
+      return [
+        `Image size is too large.`,
+        `Please use images under ${acceptableImageSizeThresholdText}.`,
       ];
     default:
       return assertNever(language);

--- a/src/features/lgtmImage.ts
+++ b/src/features/lgtmImage.ts
@@ -17,3 +17,22 @@ export const extractImageExtFromValidFileType = (
 
   return `.${fileType.replace('image/', '')}` as AcceptedTypesImageExtension;
 };
+
+const calculateFileSize = (file: File): number => {
+  const kb = 1024;
+  // eslint-disable-next-line no-magic-numbers
+  const mb = kb ** 2;
+
+  // eslint-disable-next-line no-magic-numbers
+  return Math.round((file.size / mb) * 100.0) / 100.0;
+};
+
+const acceptableSizeThreshold = 4;
+
+export const acceptableImageSizeThresholdText = `${acceptableSizeThreshold}MB`;
+
+export const isAcceptableFileSize = (file: File): boolean => {
+  const size = calculateFileSize(file);
+
+  return size <= acceptableSizeThreshold;
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/258

# Done の定義

- PRのタイトルの通り、Form側で画像サイズのバリデーション処理が実装されている事

# スクリーンショット or Storybook の URL

## Storybook上で再現するには実際に閾値（4MB）を超える画像をアップロードする

https://62729802bbcc7d004a663d4c-ftrjktmesb.chromatic.com/?path=/story/templates-uploadtemplate--view-in-japanese

## 日本語

![ja](https://user-images.githubusercontent.com/11032365/227783851-7ba63171-07aa-4ac1-aad4-2339eabe6aa6.png)

## 英語

![en](https://user-images.githubusercontent.com/11032365/227783841-01b4e196-6731-482d-9b29-69cda07b2808.png)

# 変更点概要

`UploadForm` に画像サイズのバリデーションを追加して、画像サイズの閾値を超えた場合は特別なエラーメッセージを表示させるようにした。

これでバックエンドのAPIに対する巨大なpayload送信を少しは軽減する事が期待出来るハズ。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

エラー発生時の状態をStorybook上で確認出来るようにしたほうが良いかも。（ビジュアルリグレッションテストでデザイン崩れの確認しやすいので）