### PR TITLE
Storybookの書き方をCSF3に変更

### DIFF
--- a/src/components/Button/CatButtonGroup/CatButtonGroup.stories.tsx
+++ b/src/components/Button/CatButtonGroup/CatButtonGroup.stories.tsx
@@ -1,10 +1,10 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { CatButtonGroup } from './';
 
 export default {
   component: CatButtonGroup,
 };
 
-type Story = ComponentStoryObj<typeof CatButtonGroup>;
+type Story = StoryObj<typeof CatButtonGroup>;
 
 export const Default: Story = {};

--- a/src/components/Button/CatButtonGroup/CatButtonGroup.stories.tsx
+++ b/src/components/Button/CatButtonGroup/CatButtonGroup.stories.tsx
@@ -1,10 +1,27 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { CatButtonGroup } from './';
 
-export default {
+const meta: Meta<typeof CatButtonGroup> = {
   component: CatButtonGroup,
 };
 
+export default meta;
+
 type Story = StoryObj<typeof CatButtonGroup>;
 
-export const Default: Story = {};
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/require-await
+const onClickFetchRandomCatButton = async () => {
+  console.log('call onClickFetchRandomCatButton');
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/require-await
+const onClickFetchNewArrivalCatButton = async () => {
+  console.log('call onClickFetchNewArrivalCatButton');
+};
+
+export const Default: Story = {
+  args: {
+    onClickFetchRandomCatButton,
+    onClickFetchNewArrivalCatButton,
+  },
+};

--- a/src/components/Button/CatFetchButton/CatFetchButton.stories.tsx
+++ b/src/components/Button/CatFetchButton/CatFetchButton.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { CatFetchButton } from '.';
 
-export default {
+const meta: Meta<typeof CatFetchButton> = {
   component: CatFetchButton,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof CatFetchButton>;
 

--- a/src/components/Button/CatFetchButton/CatFetchButton.stories.tsx
+++ b/src/components/Button/CatFetchButton/CatFetchButton.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { CatFetchButton } from '.';
 
 export default {
   component: CatFetchButton,
 };
 
-type Story = ComponentStoryObj<typeof CatFetchButton>;
+type Story = StoryObj<typeof CatFetchButton>;
 
 export const CatsRefreshButton: Story = {
   args: {

--- a/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.stories.tsx
+++ b/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { CatRandomCopyButton } from '.';
 
 export default {
   component: CatRandomCopyButton,
 };
 
-type Story = ComponentStoryObj<typeof CatRandomCopyButton>;
+type Story = StoryObj<typeof CatRandomCopyButton>;
 
 const callback: () => void = () =>
   // eslint-disable-next-line no-console

--- a/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.stories.tsx
+++ b/src/components/Button/CatRandomCopyButton/CatRandomCopyButton.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { CatRandomCopyButton } from '.';
 
-export default {
+const meta: Meta<typeof CatRandomCopyButton> = {
   component: CatRandomCopyButton,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof CatRandomCopyButton>;
 

--- a/src/components/Button/GitHubLoginButton/GitHubLoginButton.stories.tsx
+++ b/src/components/Button/GitHubLoginButton/GitHubLoginButton.stories.tsx
@@ -1,10 +1,10 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { GitHubLoginButton } from './GitHubLoginButton';
 
 export default {
   component: GitHubLoginButton,
 };
 
-type Story = ComponentStoryObj<typeof GitHubLoginButton>;
+type Story = StoryObj<typeof GitHubLoginButton>;
 
 export const Default: Story = {};

--- a/src/components/Button/GitHubLoginButton/GitHubLoginButton.stories.tsx
+++ b/src/components/Button/GitHubLoginButton/GitHubLoginButton.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { GitHubLoginButton } from './GitHubLoginButton';
 
-export default {
+const meta: Meta<typeof GitHubLoginButton> = {
   component: GitHubLoginButton,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof GitHubLoginButton>;
 

--- a/src/components/Button/UploadCatButton/UploadCatButton.stories.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { UploadCatButton } from './index';
 
 export default {
   component: UploadCatButton,
 };
 
-type Story = ComponentStoryObj<typeof UploadCatButton>;
+type Story = StoryObj<typeof UploadCatButton>;
 
 export const Default: Story = {
   args: {

--- a/src/components/Button/UploadCatButton/UploadCatButton.stories.tsx
+++ b/src/components/Button/UploadCatButton/UploadCatButton.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { UploadCatButton } from './index';
 
-export default {
+const meta: Meta<typeof UploadCatButton> = {
   component: UploadCatButton,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof UploadCatButton>;
 

--- a/src/components/ErrorContent/ErrorContent.stories.tsx
+++ b/src/components/ErrorContent/ErrorContent.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import Image from 'next/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
@@ -7,9 +7,11 @@ import serviceUnavailable from '../../images/service_unavailable.webp';
 
 import { ErrorContent } from './';
 
-export default {
+const meta: Meta<typeof ErrorContent> = {
   component: ErrorContent,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof ErrorContent>;
 

--- a/src/components/ErrorContent/ErrorContent.stories.tsx
+++ b/src/components/ErrorContent/ErrorContent.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import Image from 'next/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
@@ -11,7 +11,7 @@ export default {
   component: ErrorContent,
 };
 
-type Story = ComponentStoryObj<typeof ErrorContent>;
+type Story = StoryObj<typeof ErrorContent>;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
 const notFoundSrc = notFound.src;

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { Footer } from './';
 
-export default {
+const meta: Meta<typeof Footer> = {
   component: Footer,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof Footer>;
 

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { Footer } from './';
 
 export default {
   component: Footer,
 };
 
-type Story = ComponentStoryObj<typeof Footer>;
+type Story = StoryObj<typeof Footer>;
 
 export const ViewInJapanese: Story = {
   args: { language: 'ja' },

--- a/src/components/GlobalMenu/GlobalMenu.stories.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { GlobalMenu } from './';
 
-export default {
+const meta: Meta<typeof GlobalMenu> = {
   component: GlobalMenu,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof GlobalMenu>;
 

--- a/src/components/GlobalMenu/GlobalMenu.stories.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { GlobalMenu } from './';
 
 export default {
   component: GlobalMenu,
 };
 
-type Story = ComponentStoryObj<typeof GlobalMenu>;
+type Story = StoryObj<typeof GlobalMenu>;
 
 export const ViewInJapanese: Story = {
   args: { language: 'ja' },

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { Header } from './';
 
-export default {
+const meta: Meta<typeof Header> = {
   component: Header,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof Header>;
 

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { Header } from './';
 
 export default {
   component: Header,
 };
 
-type Story = ComponentStoryObj<typeof Header>;
+type Story = StoryObj<typeof Header>;
 
 export const LanguageJa: Story = {
   args: {

--- a/src/components/Icon/LibraryBooks/MdLibraryBooks.stories.tsx
+++ b/src/components/Icon/LibraryBooks/MdLibraryBooks.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { LibraryBooks } from './';
 
 export default {
   component: LibraryBooks,
 };
 
-type Story = ComponentStoryObj<typeof LibraryBooks>;
+type Story = StoryObj<typeof LibraryBooks>;
 
 export const Default: Story = {
   args: { text: '利用規約' },

--- a/src/components/Icon/LibraryBooks/MdLibraryBooks.stories.tsx
+++ b/src/components/Icon/LibraryBooks/MdLibraryBooks.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { LibraryBooks } from './';
 
-export default {
+const meta: Meta<typeof LibraryBooks> = {
   component: LibraryBooks,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof LibraryBooks>;
 

--- a/src/components/LgtmImages/LgtmImages.stories.tsx
+++ b/src/components/LgtmImages/LgtmImages.stories.tsx
@@ -1,11 +1,13 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { type LgtmImage } from '../../types';
 
 import { LgtmImages } from './';
 
-export default {
+const meta: Meta<typeof LgtmImages> = {
   component: LgtmImages,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof LgtmImages>;
 

--- a/src/components/LgtmImages/LgtmImages.stories.tsx
+++ b/src/components/LgtmImages/LgtmImages.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { type LgtmImage } from '../../types';
 
 import { LgtmImages } from './';
@@ -7,7 +7,7 @@ export default {
   component: LgtmImages,
 };
 
-type Story = ComponentStoryObj<typeof LgtmImages>;
+type Story = StoryObj<typeof LgtmImages>;
 
 const images: LgtmImage[] = [
   {

--- a/src/components/MarkdownContents/MarkdownContents.stories.tsx
+++ b/src/components/MarkdownContents/MarkdownContents.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { MarkdownContents } from './';
 
 export default {
   component: MarkdownContents,
 };
 
-type Story = ComponentStoryObj<typeof MarkdownContents>;
+type Story = StoryObj<typeof MarkdownContents>;
 
 const markdown = `
   # 🐱ねこの種類🐱

--- a/src/components/MarkdownContents/MarkdownContents.stories.tsx
+++ b/src/components/MarkdownContents/MarkdownContents.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { MarkdownContents } from './';
 
-export default {
+const meta: Meta<typeof MarkdownContents> = {
   component: MarkdownContents,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof MarkdownContents>;
 

--- a/src/components/MarkdownPageTitle/MarkdownPageTitle.stories.tsx
+++ b/src/components/MarkdownPageTitle/MarkdownPageTitle.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { MarkdownPageTitle } from './';
 
-export default {
+const meta: Meta<typeof MarkdownPageTitle> = {
   component: MarkdownPageTitle,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof MarkdownPageTitle>;
 

--- a/src/components/MarkdownPageTitle/MarkdownPageTitle.stories.tsx
+++ b/src/components/MarkdownPageTitle/MarkdownPageTitle.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { MarkdownPageTitle } from './';
 
 export default {
   component: MarkdownPageTitle,
 };
 
-type Story = ComponentStoryObj<typeof MarkdownPageTitle>;
+type Story = StoryObj<typeof MarkdownPageTitle>;
 
 export const Default: Story = {
   args: { text: '利用規約' },

--- a/src/components/Upload/UploadForm/UploadForm.stories.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { createSuccessResult } from '../../../features';
 import type {
   AcceptedTypesImageExtension,
@@ -10,9 +10,11 @@ import { sleep } from '../../../utils';
 
 import { UploadForm } from '.';
 
-export default {
+const meta: Meta<typeof UploadForm> = {
   component: UploadForm,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof UploadForm>;
 

--- a/src/components/Upload/UploadForm/UploadForm.stories.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { createSuccessResult } from '../../../features';
 import type {
   AcceptedTypesImageExtension,
@@ -14,7 +14,7 @@ export default {
   component: UploadForm,
 };
 
-type Story = ComponentStoryObj<typeof UploadForm>;
+type Story = StoryObj<typeof UploadForm>;
 
 const imageValidator: ImageValidator = async (
   image: string,

--- a/src/components/Upload/UploadModal/UploadModal.stories.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { UploadModal } from './';
 
-export default {
+const meta: Meta<typeof UploadModal> = {
   component: UploadModal,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof UploadModal>;
 

--- a/src/components/Upload/UploadModal/UploadModal.stories.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { UploadModal } from './';
 
 export default {
   component: UploadModal,
 };
 
-type Story = ComponentStoryObj<typeof UploadModal>;
+type Story = StoryObj<typeof UploadModal>;
 
 export const ViewInJapanese: Story = {
   args: {

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.stories.tsx
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { UploadProgressBar } from '.';
 
-export default {
+const meta: Meta<typeof UploadProgressBar> = {
   component: UploadProgressBar,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof UploadProgressBar>;
 

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.stories.tsx
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { UploadProgressBar } from '.';
 
 export default {
   component: UploadProgressBar,
 };
 
-type Story = ComponentStoryObj<typeof UploadProgressBar>;
+type Story = StoryObj<typeof UploadProgressBar>;
 
 export const ViewInJapanese: Story = {
   args: { language: 'ja' },

--- a/src/components/Upload/UploadTitleArea/UploadTitleArea.stories.tsx
+++ b/src/components/Upload/UploadTitleArea/UploadTitleArea.stories.tsx
@@ -1,11 +1,11 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { UploadTitleArea } from './index';
 
 export default {
   component: UploadTitleArea,
 };
 
-type Story = ComponentStoryObj<typeof UploadTitleArea>;
+type Story = StoryObj<typeof UploadTitleArea>;
 
 export const ViewInJapanese: Story = {
   args: { language: 'ja' },

--- a/src/components/Upload/UploadTitleArea/UploadTitleArea.stories.tsx
+++ b/src/components/Upload/UploadTitleArea/UploadTitleArea.stories.tsx
@@ -1,9 +1,11 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { UploadTitleArea } from './index';
 
-export default {
+const meta: Meta<typeof UploadTitleArea> = {
   component: UploadTitleArea,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof UploadTitleArea>;
 

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.stories.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.stories.tsx
@@ -1,10 +1,12 @@
 import type { FC } from 'react';
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { ResponsiveLayout } from './';
 
-export default {
+const meta: Meta<typeof ResponsiveLayout> = {
   component: ResponsiveLayout,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof ResponsiveLayout>;
 

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.stories.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.stories.tsx
@@ -1,12 +1,12 @@
 import type { FC } from 'react';
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { ResponsiveLayout } from './';
 
 export default {
   component: ResponsiveLayout,
 };
 
-type Story = ComponentStoryObj<typeof ResponsiveLayout>;
+type Story = StoryObj<typeof ResponsiveLayout>;
 
 const JpContents: FC = () => (
   <>

--- a/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import Image from 'next/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
@@ -7,9 +7,11 @@ import serviceUnavailable from '../../images/service_unavailable.webp';
 
 import { ErrorTemplate } from './';
 
-export default {
+const meta: Meta<typeof ErrorTemplate> = {
   component: ErrorTemplate,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof ErrorTemplate>;
 

--- a/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
+++ b/src/templates/ErrorTemplate/ErrorTemplate.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import Image from 'next/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
@@ -11,7 +11,7 @@ export default {
   component: ErrorTemplate,
 };
 
-type Story = ComponentStoryObj<typeof ErrorTemplate>;
+type Story = StoryObj<typeof ErrorTemplate>;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
 const notFoundSrc = notFound.src;

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { MarkdownContents } from '../../components/MarkdownContents';
 import { useSwitchLanguage } from '../../hooks';
 import type { Language } from '../../types';
@@ -248,7 +248,7 @@ export default {
   component: EnhanceTermsOrPrivacyTemplate,
 };
 
-type Story = ComponentStoryObj<typeof EnhanceTermsOrPrivacyTemplate>;
+type Story = StoryObj<typeof EnhanceTermsOrPrivacyTemplate>;
 
 export const ViewPrivacyPolicyInJapanese: Story = {
   args: { type: 'privacy', language: 'ja' },

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.stories.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { MarkdownContents } from '../../components/MarkdownContents';
 import { useSwitchLanguage } from '../../hooks';
 import type { Language } from '../../types';
@@ -244,9 +244,11 @@ const EnhanceTermsOrPrivacyTemplate: FC<Props> = ({ type, language }) => {
   );
 };
 
-export default {
+const meta: Meta<typeof EnhanceTermsOrPrivacyTemplate> = {
   component: EnhanceTermsOrPrivacyTemplate,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof EnhanceTermsOrPrivacyTemplate>;
 

--- a/src/templates/TopTemplate/TopTemplate.stories.tsx
+++ b/src/templates/TopTemplate/TopTemplate.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import Image from 'next/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
@@ -6,9 +6,11 @@ import internalServerError from '../../images/internal_server_error.webp';
 import { type LgtmImage, type CatImagesFetcher } from '../../types';
 import { TopTemplate } from './.';
 
-export default {
+const meta: Meta<typeof TopTemplate> = {
   component: TopTemplate,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof TopTemplate>;
 

--- a/src/templates/TopTemplate/TopTemplate.stories.tsx
+++ b/src/templates/TopTemplate/TopTemplate.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import Image from 'next/image';
 
 import internalServerError from '../../images/internal_server_error.webp';
@@ -10,7 +10,7 @@ export default {
   component: TopTemplate,
 };
 
-type Story = ComponentStoryObj<typeof TopTemplate>;
+type Story = StoryObj<typeof TopTemplate>;
 
 const lgtmImages: LgtmImage[] = [
   {

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { ComponentStoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import Image from 'next/image';
 
 import { createSuccessResult } from '../../features';
@@ -67,7 +67,7 @@ export default {
   component: UploadTemplate,
 };
 
-type Story = ComponentStoryObj<typeof UploadTemplate>;
+type Story = StoryObj<typeof UploadTemplate>;
 
 export const ViewInJapanese: Story = {
   args: {

--- a/src/templates/UploadTemplate/UploadTemplate.stories.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import Image from 'next/image';
 
 import { createSuccessResult } from '../../features';
@@ -63,9 +63,11 @@ const onClickMarkdownSourceCopyButton: () => void = () =>
 
 const appUrl = 'http://localhost:2222';
 
-export default {
+const meta: Meta<typeof UploadTemplate> = {
   component: UploadTemplate,
 };
+
+export default meta;
 
 type Story = StoryObj<typeof UploadTemplate>;
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/266

# Done の定義

- Storybookの書き方がCSF3に変更されている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-isqafoksgv.chromatic.com/?path=/story/components-markdownpagetitle--default

# 変更点概要

元々の書き方（CSF2）が非推奨になっているようなので https://storybook.js.org/docs/react/migration-guide#csf2-to-csf3 を参考に `npx storybook@latest migrate csf-2-to-3 --glob="src/**/*.stories.tsx"` を実行して置き換えた後に `Meta` の型定義を追加する形で対応。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし