### PR TITLE
Package利用側でCSSが上手くimport出来なかったので設定を変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "devDependencies": {
         "@storybook/addon-a11y": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.es.js"
-    }
+    },
+    "./style.css": "./dist/style.css"
   },
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "build": "rm -rf dist && vite build && cp src/styles/globals.css dist/globals.css",
+    "build": "rm -rf dist && vite build",
     "lint:prettier": "prettier --cache --check .",
     "fix:prettier": "npm run lint:prettier -- --write",
     "lint:eslint": "eslint --cache .",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import './styles/globals.css';
 export { useSwitchLanguage } from './hooks';
 
 export * from './templates';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/273

# Done の定義

- Package利用側が `import '@nekochans/lgtm-cat-ui/style.css';` で `style.css` をimport出来る設定を追加する

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-rfmgqpdrjz.chromatic.com/

# 変更点概要

https://github.com/nekochans/lgtm-cat-ui/pull/272 の内容をreleaseしてPackageを利用してみたが以下のようにCSSをimportしないとデザイン崩れが発生してしまう状況になってしまった。

```
import 'node_modules/@nekochans/lgtm-cat-ui/dist/globals.css';
import 'node_modules/@nekochans/lgtm-cat-ui/dist/style.css';
```

そこで以下の2点の対応を行った。

- エントリーポイントに `globals.css` を含める事でPackage利用者は `style.css` だけをimportすれば良いように変更
- `import '@nekochans/lgtm-cat-ui/style.css';` で `style.css` をimport出来る設定を追加

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

本来はrelease用のPRを別に作るのだが、今回はこのPRの内容だけreleaseしたいので、PackageのバージョンアップもこのPRに含めている。