### PR TITLE
LanguageMenu をCSS Moduleを使った形に置換え

### DIFF
--- a/src/components/Header/LanguageMenu.module.css
+++ b/src/components/Header/LanguageMenu.module.css
@@ -19,7 +19,7 @@
   }
 }
 
-.en-text-wrapper {
+.text-wrapper {
   display: flex;
   flex: none;
   flex-direction: row;
@@ -30,20 +30,13 @@
   height: 39px;
   padding: 10px 0;
   background: var(--text-wrapper-background);
+}
+
+.en-text-wrapper {
   order: 0;
 }
 
 .ja-text-wrapper {
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: flex-start;
-  width: 125px;
-  height: 39px;
-  padding: 10px 0;
-  background: var(--text-wrapper-background);
   order: 2;
 }
 

--- a/src/components/Header/LanguageMenu.module.css
+++ b/src/components/Header/LanguageMenu.module.css
@@ -1,0 +1,78 @@
+:root {
+  --text-wrapper-background: rgba(54, 46, 43, 0.4);
+  --separator-border: rgba(54, 46, 43, 0.5);
+}
+
+.wrapper {
+  position: absolute;
+  right: 20px;
+  bottom: -70px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0;
+}
+
+@media (max-width: var(--media-query-default-size)) {
+  .wrapper {
+    right: 0;
+  }
+}
+
+.en-text-wrapper {
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: flex-start;
+  width: 125px;
+  height: 39px;
+  padding: 10px 0;
+  background: var(--text-wrapper-background);
+  order: 0;
+}
+
+.ja-text-wrapper {
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: flex-start;
+  width: 125px;
+  height: 39px;
+  padding: 10px 0;
+  background: var(--text-wrapper-background);
+  order: 2;
+}
+
+.link-text {
+  display: block;
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 125px;
+  height: 19px;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 19px;
+  color: var(--background-color);
+  text-align: center;
+  cursor: pointer;
+}
+
+.link {
+  text-decoration: none;
+}
+
+.separator {
+  flex: none;
+  flex-grow: 0;
+  order: 1;
+  width: 125px;
+  height: 0;
+  border: 1px solid var(--separator-border);
+}

--- a/src/components/Header/LanguageMenu.module.css.d.ts
+++ b/src/components/Header/LanguageMenu.module.css.d.ts
@@ -1,0 +1,9 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly 'en-text-wrapper': string;
+  readonly 'ja-text-wrapper': string;
+  readonly 'link-text': string;
+  readonly link: string;
+  readonly separator: string;
+};
+export = styles;

--- a/src/components/Header/LanguageMenu.module.css.d.ts
+++ b/src/components/Header/LanguageMenu.module.css.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly wrapper: string;
+  readonly 'text-wrapper': string;
   readonly 'en-text-wrapper': string;
   readonly 'ja-text-wrapper': string;
   readonly 'link-text': string;

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -11,7 +11,7 @@ export type Props = {
 
 export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
   <nav className={styles.wrapper}>
-    <span className={styles['en-text-wrapper']}>
+    <span className={`${styles['text-wrapper']} ${styles['en-text-wrapper']}`}>
       <Link href={currentUrlPath} locale="en" className={styles.link}>
         <span
           className={styles['link-text']}
@@ -23,7 +23,7 @@ export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
       </Link>
     </span>
     <span className={styles.separator} />
-    <span className={styles['ja-text-wrapper']}>
+    <span className={`${styles['text-wrapper']} ${styles['ja-text-wrapper']}`}>
       <Link
         href={currentUrlPath}
         locale="ja"

--- a/src/components/Header/LanguageMenu.tsx
+++ b/src/components/Header/LanguageMenu.tsx
@@ -1,89 +1,8 @@
 import type { FC } from 'react';
 import Link from 'next/link';
 import { FaAngleRight } from 'react-icons/fa';
-import styled, { css } from 'styled-components';
-import { mixins } from '../../styles';
 import type { Language } from '../../types';
-
-const textWrapperStyle = css`
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: flex-start;
-  width: 125px;
-  height: 39px;
-  padding: 10px 0;
-  background: rgba(54, 46, 43, 0.4);
-`;
-
-const _Wrapper = styled.nav`
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    right: 0;
-  }
-  position: absolute;
-  right: 20px;
-  bottom: -70px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0;
-`;
-
-const _EnTextWrapper = styled.span`
-  ${textWrapperStyle};
-  order: 0;
-`;
-
-const _EnText = styled.span`
-  display: block;
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: 125px;
-  height: 19px;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 19px;
-  color: ${mixins.colors.background};
-  text-align: center;
-  cursor: pointer;
-`;
-
-const _Separator = styled.span`
-  flex: none;
-  flex-grow: 0;
-  order: 1;
-  width: 125px;
-  height: 0;
-  border: 1px solid rgba(54, 46, 43, 0.5);
-`;
-
-const _JaTextWrapper = styled.span`
-  ${textWrapperStyle};
-  order: 2;
-`;
-
-const _JaText = styled.span`
-  display: block;
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: 125px;
-  height: 19px;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 19px;
-  color: ${mixins.colors.background};
-  text-align: center;
-  text-decoration: none;
-  cursor: pointer;
-`;
+import styles from './LanguageMenu.module.css';
 
 export type Props = {
   language: Language;
@@ -91,36 +10,34 @@ export type Props = {
 };
 
 export const LanguageMenu: FC<Props> = ({ language, currentUrlPath }) => (
-  <_Wrapper>
-    <_EnTextWrapper>
-      <Link
-        href={currentUrlPath}
-        locale="en"
-        style={{ textDecoration: 'none' }}
-      >
-        <_EnText data-gtm-click="language-menu-en-link">
+  <nav className={styles.wrapper}>
+    <span className={styles['en-text-wrapper']}>
+      <Link href={currentUrlPath} locale="en" className={styles.link}>
+        <span
+          className={styles['link-text']}
+          data-gtm-click="language-menu-en-link"
+        >
           {language === 'en' ? <FaAngleRight /> : ''}
           English
-        </_EnText>
+        </span>
       </Link>
-      <_EnText>
-        {language === 'en' ? <FaAngleRight /> : ''}
-        English
-      </_EnText>
-    </_EnTextWrapper>
-    <_Separator />
-    <_JaTextWrapper>
+    </span>
+    <span className={styles.separator} />
+    <span className={styles['ja-text-wrapper']}>
       <Link
         href={currentUrlPath}
         locale="ja"
         prefetch={false}
-        style={{ textDecoration: 'none' }}
+        className={styles.link}
       >
-        <_JaText data-gtm-click="language-menu-ja-link">
+        <span
+          className={styles['link-text']}
+          data-gtm-click="language-menu-ja-link"
+        >
           {language === 'ja' ? <FaAngleRight /> : ''}
           日本語
-        </_JaText>
+        </span>
       </Link>
-    </_JaTextWrapper>
-  </_Wrapper>
+    </span>
+  </nav>
 );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/276

# Done の定義

- `src/components/Header/LanguageMenu` がCSS Moduleに置き換わっている事

# スクリーンショット or Storybook の URL

- https://62729802bbcc7d004a663d4c-gyyhxkcgdo.chromatic.com/?path=/story/components-header--language-ja-menu-is-open
- https://62729802bbcc7d004a663d4c-gyyhxkcgdo.chromatic.com/?path=/story/components-header--language-en-menu-is-open

# 変更点概要

タイトルの通り。

今回は単純な変更だとデザイン崩れが発生したので少しリファクタリングも行っている。

具体的には `text-decoration: none;` を `Link` Componentに対して適応している点です。

# レビュアーに重点的にチェックして欲しい点

CSSの書き方でリファクタリング出来る余地があれば知りたい:pray:

# 補足情報

特になし