### PR TITLE
LanguageButton をCSS Modulesを使った形に置換え

### DIFF
--- a/src/components/Header/LanguageButton.module.css
+++ b/src/components/Header/LanguageButton.module.css
@@ -12,7 +12,7 @@
   border-radius: 4px;
 }
 
-@media (max-width: var(--media-query-default-size)) {
+@media (max-width: 767px) {
   .wrapper {
     padding: 12px 0;
   }

--- a/src/components/Header/LanguageButton.module.css
+++ b/src/components/Header/LanguageButton.module.css
@@ -1,0 +1,37 @@
+.wrapper {
+  box-sizing: border-box;
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  order: 1;
+  padding: 12px 20px;
+  border-radius: 4px;
+}
+
+@media (max-width: var(--media-query-default-size)) {
+  .wrapper {
+    padding: 12px 0;
+  }
+}
+
+.text {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 19px;
+  color: var(--primary-color);
+  cursor: pointer;
+}
+
+.fa-caret-down {
+  color: var(--primary-color);
+  cursor: pointer;
+}

--- a/src/components/Header/LanguageButton.module.css.d.ts
+++ b/src/components/Header/LanguageButton.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly text: string;
+  readonly 'fa-caret-down': string;
+};
+export = styles;

--- a/src/components/Header/LanguageButton.tsx
+++ b/src/components/Header/LanguageButton.tsx
@@ -1,50 +1,16 @@
 import type { FC, MouseEvent } from 'react';
 import { FaCaretDown } from 'react-icons/fa';
-import styled from 'styled-components';
-import { mixins } from '../../styles';
-
-const _Wrapper = styled.div`
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    padding: 12px 0;
-  }
-  box-sizing: border-box;
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: center;
-  justify-content: center;
-  order: 1;
-  padding: 12px 20px;
-  border-radius: 4px;
-`;
-
-const _Text = styled.p`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 19px;
-  color: ${mixins.colors.primary};
-  cursor: pointer;
-`;
-
-const faCaretDownStyle = {
-  color: `${mixins.colors.primary}`,
-  cursor: 'pointer',
-};
+import styles from './LanguageButton.module.css';
 
 type Props = {
   onClick: (event: MouseEvent<HTMLDivElement>) => void;
 };
 
 export const LanguageButton: FC<Props> = ({ onClick }) => (
-  <_Wrapper onClick={onClick}>
-    <_Text>Language</_Text>
-    <FaCaretDown style={faCaretDownStyle} />
-  </_Wrapper>
+  // TODO 今はESLintのエラーを無視しているが https://github.com/nekochans/lgtm-cat-ui/issues/279 で修正する
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  <div className={styles.wrapper} onClick={onClick}>
+    <p className={styles.text}>Language</p>
+    <FaCaretDown className={styles['fa-caret-down']} />
+  </div>
 );

--- a/src/components/Header/LanguageMenu.module.css
+++ b/src/components/Header/LanguageMenu.module.css
@@ -13,7 +13,7 @@
   padding: 0;
 }
 
-@media (max-width: var(--media-query-default-size)) {
+@media (max-width: 767px) {
   .wrapper {
     right: 0;
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,7 +8,6 @@
   --sub-text-color: #8e7e78;
   --white-color: #ffffff;
   --background-color: #faf9f7;
-  --media-query-default-size: 767px;
 }
 
 .button-base {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/276

# Done の定義

- `LanguageButton` がCSS Modules を使った形に置き換わっている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-ineoogfrln.chromatic.com/?path=/story/components-header--language-en-menu-is-open

# 変更点概要

タイトルの通り  `LanguageButton` をCSS Modules を使った形に置換え。

メディアクエリ内ではCSS変数を利用出来ないのでブレークポイントの値はハードコードするように変更。

https://github.com/nekochans/lgtm-cat-ui/pull/277 で対応した時のメディアクエリも実は機能していなかった事が分かったので今回一緒に修正を行った。

# レビュアーに重点的にチェックして欲しい点

メディアクエリのブレークポイントを管理するいい方法があれば知りたい:pray:

CSS ModulesではSassも利用可能だが、この為だけにSassを入れるのはちょっと・・・という感じ・・・

# 補足情報

https://zenn.dev/link/comments/598944c22b094d