### PR TITLE
GlobalMenu をCSSModuleに置換え

### DIFF
--- a/src/components/GlobalMenu/GlobalMenu.module.css
+++ b/src/components/GlobalMenu/GlobalMenu.module.css
@@ -1,0 +1,85 @@
+.wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+  justify-content: center;
+  width: 69px;
+  height: 35px;
+  padding: 10px 22px 7px 0;
+}
+
+.header-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 10px 22px 7px 0;
+}
+
+.fa-times-wrapper {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 30px;
+  height: 30px;
+}
+
+.fa-times {
+  font-style: normal;
+  font-weight: 900;
+  font-size: 30px;
+  line-height: 30px;
+  color: var(--primary-color);
+  cursor: pointer;
+}
+
+.fa-cloud-upload-alt {
+  font-style: normal;
+  font-weight: 900;
+  font-size: 16px;
+  line-height: 30px;
+  color: var(--primary-color);
+  margin-right: 10px;
+}
+
+.link-group-wrapper {
+  position: absolute;
+  top: 73px;
+  left: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 305px;
+  height: 180px;
+  padding: 0;
+}
+
+.link-wrapper {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 305px;
+  height: 45px;
+}
+
+.link-text {
+  display: flex;
+  align-items: center;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 30px;
+  color: var(--primary-color);
+  text-decoration-line: underline;
+  cursor: pointer;
+}
+
+.underline {
+  box-sizing: border-box;
+  background: var(--background-color);
+  border-bottom: 1px solid var(--sub-color);
+}

--- a/src/components/GlobalMenu/GlobalMenu.module.css.d.ts
+++ b/src/components/GlobalMenu/GlobalMenu.module.css.d.ts
@@ -1,0 +1,12 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly 'header-wrapper': string;
+  readonly 'fa-times-wrapper': string;
+  readonly 'fa-times': string;
+  readonly 'fa-cloud-upload-alt': string;
+  readonly 'link-group-wrapper': string;
+  readonly 'link-wrapper': string;
+  readonly 'link-text': string;
+  readonly underline: string;
+};
+export = styles;

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -1,152 +1,80 @@
 import type { FC } from 'react';
 import Link from 'next/link';
 import { FaTimes, FaCloudUploadAlt } from 'react-icons/fa';
-import styled from 'styled-components';
 import {
   createPrivacyPolicyLinksFromLanguages,
   createTermsOfUseLinksFromLanguages,
 } from '../../features';
-import { mixins } from '../../styles';
 
 import type { Language } from '../../types';
-
-const _Wrapper = styled.div`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  align-items: flex-start;
-  justify-content: center;
-  width: 69px;
-  height: 35px;
-  padding: 10px 22px 7px 0;
-`;
-
-const _HeaderWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 10px 22px 7px 0;
-`;
-
-const _FaTimesWrapper = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: 30px;
-  height: 30px;
-`;
-
-const faTimesStyle = {
-  fontStyle: 'normal',
-  fontWeight: 900,
-  fontSize: '30px',
-  lineHeight: '30px',
-  color: `${mixins.colors.primary}`,
-  cursor: 'pointer',
-};
-
-const _LinkGroupWrapper = styled.div`
-  position: absolute;
-  top: 73px;
-  left: 15px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  width: 305px;
-  height: 180px;
-  padding: 0;
-`;
-
-const _LinkWrapper = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: 305px;
-  height: 45px;
-`;
-
-const _LinkText = styled.span`
-  display: flex;
-  align-items: center;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 30px;
-  color: ${mixins.colors.primary};
-  text-decoration-line: underline;
-  cursor: pointer;
-`;
-
-const _UnderLine = styled.div`
-  box-sizing: border-box;
-  background: ${mixins.colors.background};
-  border-bottom: 1px solid ${mixins.colors.sub};
-`;
-
-const faCloudUploadAltStyle = {
-  fontStyle: 'normal',
-  fontWeight: 900,
-  fontSize: '16px',
-  lineHeight: '30px',
-  color: `${mixins.colors.primary}`,
-  marginRight: '10px',
-};
+import styles from './GlobalMenu.module.css';
 
 export type Props = {
   language: Language;
   onClickCloseButton: () => void;
 };
 
-// eslint-disable-next-line max-lines-per-function
 export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
   const termsOfUseLinks = createTermsOfUseLinksFromLanguages(language);
-
   const privacyPolicyLinks = createPrivacyPolicyLinksFromLanguages(language);
 
   return (
-    <_Wrapper>
-      <_HeaderWrapper>
-        <_FaTimesWrapper onClick={onClickCloseButton}>
-          <FaTimes style={faTimesStyle} />
-        </_FaTimesWrapper>
-      </_HeaderWrapper>
-      <_LinkGroupWrapper>
-        <_LinkWrapper>
+    <div className={styles.wrapper}>
+      <div className={styles['header-wrapper']}>
+        <div
+          className={styles['fa-times-wrapper']}
+          onClick={onClickCloseButton}
+        >
+          <FaTimes className={styles['fa-times']} />
+        </div>
+      </div>
+      <div className={styles['link-group-wrapper']}>
+        <div className={styles['link-wrapper']}>
           <Link href="/" prefetch={false}>
-            <_LinkText data-gtm-click="global-menu-top-link">TOP</_LinkText>
+            <span
+              className={styles['link-text']}
+              data-gtm-click="global-menu-top-link"
+            >
+              TOP
+            </span>
           </Link>
-          <_UnderLine />
-        </_LinkWrapper>
-        <_LinkWrapper>
+          <div className={styles.underline} />
+        </div>
+        <div className={styles['link-wrapper']}>
           <Link href="/upload" prefetch={false}>
-            <_LinkText data-gtm-click="global-menu-upload-cat-link">
-              <FaCloudUploadAlt style={faCloudUploadAltStyle} />
+            <span
+              className={styles['link-text']}
+              data-gtm-click="global-menu-upload-cat-link"
+            >
+              <FaCloudUploadAlt className={styles['fa-cloud-upload-alt']} />
               Upload new Cats
-            </_LinkText>
+            </span>
           </Link>
-          <_UnderLine />
-        </_LinkWrapper>
-        <_LinkWrapper>
+          <div className={styles.underline} />
+        </div>
+        <div className={styles['link-wrapper']}>
           <Link href={termsOfUseLinks.link} prefetch={false}>
-            <_LinkText data-gtm-click="global-menu-terms-link">
+            <span
+              className={styles['link-text']}
+              data-gtm-click="global-menu-terms-link"
+            >
               {termsOfUseLinks.text}
-            </_LinkText>
+            </span>
           </Link>
-          <_UnderLine />
-        </_LinkWrapper>
-        <_LinkWrapper>
+          <div className={styles.underline} />
+        </div>
+        <div className={styles['link-wrapper']}>
           <Link href={privacyPolicyLinks.link} prefetch={false}>
-            <_LinkText data-gtm-click="global-menu-terms-link">
+            <span
+              className={styles['link-text']}
+              data-gtm-click="global-menu-terms-link"
+            >
               {privacyPolicyLinks.text}
-            </_LinkText>
+            </span>
           </Link>
-          <_UnderLine />
-        </_LinkWrapper>
-      </_LinkGroupWrapper>
-    </_Wrapper>
+          <div className={styles.underline} />
+        </div>
+      </div>
+    </div>
   );
 };

--- a/src/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/components/GlobalMenu/GlobalMenu.tsx
@@ -21,12 +21,12 @@ export const GlobalMenu: FC<Props> = ({ language, onClickCloseButton }) => {
   return (
     <div className={styles.wrapper}>
       <div className={styles['header-wrapper']}>
-        <div
+        <button
           className={styles['fa-times-wrapper']}
           onClick={onClickCloseButton}
         >
           <FaTimes className={styles['fa-times']} />
-        </div>
+        </button>
       </div>
       <div className={styles['link-group-wrapper']}>
         <div className={styles['link-wrapper']}>


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/276

# Done の定義

- `GlobalMenu` がCSS Modulesに置き換わっている事

# スクリーンショット or Storybook の URL

- https://62729802bbcc7d004a663d4c-lmimerfnnk.chromatic.com/?path=/story/components-globalmenu--view-in-japanese
- https://62729802bbcc7d004a663d4c-lmimerfnnk.chromatic.com/?path=/story/components-globalmenu--view-in-english

# 変更点概要

タイトルの通り、GlobalMenuをCSS Modulesに置換え。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

インラインコメントに記載。

以下に置換え情報をまとめてある。

https://zenn.dev/link/comments/78308033d7f51e