### PR TITLE
ErrorContent を CSS Modules を使った形に置換え

### DIFF
--- a/src/components/ErrorContent/BackToTopButton.module.css
+++ b/src/components/ErrorContent/BackToTopButton.module.css
@@ -1,0 +1,37 @@
+.link {
+  text-decoration: none;
+}
+
+.span {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 20px;
+  cursor: pointer;
+  background: var(--primary-color);
+  border-radius: 4px;
+}
+
+.span:hover {
+  opacity: 0.8;
+}
+
+.text {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 144px;
+  height: 18px;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 18px;
+  color: var(--white-color);
+}
+
+.text:hover {
+  opacity: 0.8;
+}

--- a/src/components/ErrorContent/BackToTopButton.module.css.d.ts
+++ b/src/components/ErrorContent/BackToTopButton.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly link: string;
+  readonly span: string;
+  readonly text: string;
+};
+export = styles;

--- a/src/components/ErrorContent/BackToTopButton.tsx
+++ b/src/components/ErrorContent/BackToTopButton.tsx
@@ -1,41 +1,8 @@
 import type { FC } from 'react';
 import Link from 'next/link';
-import styled from 'styled-components';
-import { mixins } from '../../styles';
 import type { Language } from '../../types';
 import { assertNever } from '../../utils';
-
-const _Span = styled.span`
-  display: flex;
-  flex-direction: row;
-  gap: 10px;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 20px;
-  cursor: pointer;
-  background: ${mixins.colors.primary};
-  border-radius: 4px;
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-const _Text = styled.span`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: 144px;
-  height: 18px;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 18px;
-  color: ${mixins.colors.white};
-  &:hover {
-    opacity: 0.8;
-  }
-`;
+import styles from './BackToTopButton.module.css';
 
 const backToTopPageText = {
   ja: 'トップページに戻る',
@@ -61,9 +28,9 @@ type Props = {
 };
 
 export const BackToTopButton: FC<Props> = ({ language }) => (
-  <Link href="/" prefetch={false} style={{ textDecoration: 'none' }}>
-    <_Span>
-      <_Text>{createBackToTopPageText(language)}</_Text>
-    </_Span>
+  <Link href="/" prefetch={false} className={styles.link}>
+    <span className={styles.span}>
+      <span className={styles.text}>{createBackToTopPageText(language)}</span>
+    </span>
   </Link>
 );

--- a/src/components/ErrorContent/ErrorContent.module.css
+++ b/src/components/ErrorContent/ErrorContent.module.css
@@ -1,0 +1,33 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 64px;
+  align-items: center;
+  justify-content: center;
+}
+
+.title {
+  font-family: Roboto, sans-serif;
+  font-size: 70px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 70px;
+  color: var(--text-color);
+  text-align: center;
+}
+
+.imageWrapper {
+  position: relative;
+  width: 240px;
+  height: 240px;
+}
+
+.message {
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 26px;
+  color: var(--text-color);
+  text-align: center;
+}

--- a/src/components/ErrorContent/ErrorContent.module.css.d.ts
+++ b/src/components/ErrorContent/ErrorContent.module.css.d.ts
@@ -1,0 +1,7 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly title: string;
+  readonly imageWrapper: string;
+  readonly message: string;
+};
+export = styles;

--- a/src/components/ErrorContent/ErrorContent.tsx
+++ b/src/components/ErrorContent/ErrorContent.tsx
@@ -1,46 +1,9 @@
 import type { FC, ReactNode } from 'react';
-import styled from 'styled-components';
-
 import { errorType, type ErrorType } from '../../features';
-import { mixins } from '../../styles';
 import type { Language } from '../../types';
 import { assertNever } from '../../utils';
-
 import { BackToTopButton } from './BackToTopButton';
-
-const _Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 64px;
-  align-items: center;
-  justify-content: center;
-`;
-
-const _Title = styled.div`
-  font-family: Roboto, sans-serif;
-  font-size: 70px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 70px;
-  color: ${mixins.colors.text};
-  text-align: center;
-`;
-
-const _ImageWrapper = styled.div`
-  position: relative;
-  width: 240px;
-  height: 240px;
-`;
-
-const _Message = styled.div`
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 26px;
-  color: ${mixins.colors.text};
-  text-align: center;
-`;
+import styles from './ErrorContent.module.css';
 
 const errorTitleText = {
   notFound: '404 Not Found',
@@ -139,14 +102,16 @@ export const ErrorContent: FC<Props> = ({
   language,
   shouldDisplayBackToTopButton,
 }) => (
-  <_Wrapper>
-    <_Title>{createErrorTitleText(type)}</_Title>
-    <_ImageWrapper>{catImage}</_ImageWrapper>
-    <_Message>{createErrorMessageText(type, language)}</_Message>
+  <div className={styles.wrapper}>
+    <div className={styles.title}>{createErrorTitleText(type)}</div>
+    <div className={styles.imageWrapper}>{catImage}</div>
+    <div className={styles.message}>
+      {createErrorMessageText(type, language)}
+    </div>
     {shouldDisplayBackToTopButton ? (
       <BackToTopButton language={language} />
     ) : (
       ''
     )}
-  </_Wrapper>
+  </div>
 );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/285

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/285 のDoneの定義を満たす実装が行われている事

# スクリーンショット or Storybook の URL

- https://62729802bbcc7d004a663d4c-wdcjgwbpbm.chromatic.com/?path=/story/components-errorcontent--not-found-view-in-japanese
- https://62729802bbcc7d004a663d4c-wdcjgwbpbm.chromatic.com/?path=/story/templates-errortemplate--not-found-view-in-japanese

# 変更点概要

タイトルの通り、ErrorContent を CSS Modules を使った形に置換え。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし