### PR TITLE
UploadForm 以外のUpload関連ComponentをCSS Modules に置換え

### DIFF
--- a/src/components/Upload/UploadButton/UploadButton.module.css
+++ b/src/components/Upload/UploadButton/UploadButton.module.css
@@ -1,0 +1,40 @@
+.button {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 20px;
+  background: var(--primary-color);
+  border-radius: 4px;
+}
+
+.button:hover {
+  opacity: 0.8;
+}
+
+.text {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 128px;
+  height: 18px;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 18px;
+  color: var(--white-color);
+}
+
+.text:hover {
+  opacity: 0.8;
+}
+
+.disabled-button {
+  opacity: 0.5;
+}
+
+.disabled-text {
+  opacity: 0.5;
+}

--- a/src/components/Upload/UploadButton/UploadButton.module.css.d.ts
+++ b/src/components/Upload/UploadButton/UploadButton.module.css.d.ts
@@ -1,0 +1,7 @@
+declare const styles: {
+  readonly button: string;
+  readonly text: string;
+  readonly 'disabled-button': string;
+  readonly 'disabled-text': string;
+};
+export = styles;

--- a/src/components/Upload/UploadButton/UploadButton.tsx
+++ b/src/components/Upload/UploadButton/UploadButton.tsx
@@ -1,63 +1,7 @@
 import type { FC, FormEventHandler } from 'react';
-import styled, { css } from 'styled-components';
-import { mixins } from '../../../styles';
 import type { Language } from '../../../types';
 import { assertNever } from '../../../utils';
-
-const buttonCss = css`
-  display: flex;
-  flex-direction: row;
-  gap: 10px;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 20px;
-  background: ${mixins.colors.primary};
-  border-radius: 4px;
-`;
-
-const hoverCss = css`
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-const _Button = styled.button`
-  ${buttonCss};
-  ${hoverCss};
-`;
-
-const buttonTextCss = css`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: 128px;
-  height: 18px;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 18px;
-  color: ${mixins.colors.white};
-`;
-
-const _Text = styled.div`
-  ${buttonTextCss};
-  ${hoverCss};
-`;
-
-const disableCss = css`
-  opacity: 0.5;
-`;
-
-const _DisableButton = styled.button`
-  ${buttonCss};
-  ${disableCss};
-`;
-
-const _DisableText = styled.div`
-  ${buttonTextCss};
-  ${disableCss};
-`;
+import styles from './UploadButton.module.css';
 
 const createText = (language: Language): string => {
   switch (language) {
@@ -79,15 +23,27 @@ type Props = {
 export const UploadButton: FC<Props> = ({ language, disabled, onClick }) => {
   if (!disabled) {
     return (
-      <_Button type="submit" disabled={disabled} onClick={onClick}>
-        <_Text>{createText(language)}</_Text>
-      </_Button>
+      <button
+        type="submit"
+        disabled={disabled}
+        onClick={onClick}
+        className={styles.button}
+      >
+        <div className={styles.text}>{createText(language)}</div>
+      </button>
     );
   }
 
   return (
-    <_DisableButton type="submit" disabled={disabled} onClick={onClick}>
-      <_DisableText>{createText(language)}</_DisableText>
-    </_DisableButton>
+    <button
+      type="submit"
+      disabled={disabled}
+      onClick={onClick}
+      className={`${styles.button} ${styles['disabled-button']}`}
+    >
+      <div className={`${styles.text} ${styles['disabled-text']}`}>
+        {createText(language)}
+      </div>
+    </button>
   );
 };

--- a/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.module.css
+++ b/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.module.css
@@ -1,0 +1,55 @@
+.wrapper {
+  box-sizing: border-box;
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: center;
+  order: 0;
+  width: 498px;
+  height: 154px;
+  padding: 30px 0;
+  background: #f7ede2;
+  border: 1px solid var(--primary-color);
+}
+
+@media (max-width: 767px) {
+  .wrapper {
+    width: 380px;
+  }
+}
+
+.icon {
+  width: 498px;
+  height: 28px;
+  font-style: normal;
+  font-weight: 900;
+  font-size: 31px;
+  line-height: 28px;
+  color: var(--primary-color);
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+}
+
+.message-text {
+  flex: none;
+  flex-grow: 0;
+  order: 1;
+  width: 498px;
+  height: 56px;
+  font-family: Noto Sans JP, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 28px;
+  color: var(--primary-color);
+  text-align: center;
+}
+
+@media (max-width: 767px) {
+  .message-text {
+    width: 380px;
+  }
+}

--- a/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.module.css.d.ts
+++ b/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly icon: string;
+  readonly 'message-text': string;
+};
+export = styles;

--- a/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
+++ b/src/components/Upload/UploadErrorMessageArea/UploadErrorMessageArea.tsx
@@ -1,69 +1,18 @@
 import type { FC } from 'react';
 import { FaExclamationTriangle } from 'react-icons/fa';
-import styled from 'styled-components';
-import { mixins } from '../../../styles';
+import styles from './UploadErrorMessageArea.module.css';
 
 type Props = {
   messages: string[];
 };
 
-const _Wrapper = styled.div`
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    width: 380px;
-  }
-  box-sizing: border-box;
-  display: flex;
-  flex: none;
-  flex-direction: column;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: center;
-  order: 0;
-  width: 498px;
-  height: 154px;
-  padding: 30px 0;
-  background: #f7ede2;
-  border: 1px solid ${mixins.colors.primary};
-`;
-
-const faExclamationTriangleStyle = {
-  width: '498px',
-  height: '28px',
-  fontStyle: 'normal',
-  fontWeight: 900,
-  fontSize: '31px',
-  lineHeight: '28px',
-  color: `${mixins.colors.primary}`,
-  flex: 'none',
-  order: 0,
-  flexGrow: 0,
-};
-
-const _MessageText = styled.span`
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    width: 380px;
-  }
-  flex: none;
-  flex-grow: 0;
-  order: 1;
-  width: 498px;
-  height: 56px;
-  font-family: Noto Sans JP, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 28px;
-  color: ${mixins.colors.primary};
-  text-align: center;
-`;
-
 export const UploadErrorMessageArea: FC<Props> = ({ messages }) => (
-  <_Wrapper>
-    <FaExclamationTriangle style={faExclamationTriangleStyle} />
-    <_MessageText>
+  <div className={styles.wrapper}>
+    <FaExclamationTriangle className={styles.icon} />
+    <span className={styles['message-text']}>
       {messages.map((message, index) => (
         <p key={index}>{message}</p>
       ))}
-    </_MessageText>
-  </_Wrapper>
+    </span>
+  </div>
 );

--- a/src/components/Upload/UploadModal/ButtonGroup.module.css
+++ b/src/components/Upload/UploadModal/ButtonGroup.module.css
@@ -1,0 +1,81 @@
+.wrapper {
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+  order: 1;
+  padding: 0;
+}
+
+.cancel-button {
+  box-sizing: border-box;
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  order: 0;
+  padding: 12px 20px;
+  background: var(--background-color);
+  border: 1px solid var(--sub-text-color);
+  border-radius: 4px;
+}
+
+.cancel-button:hover {
+  opacity: 0.8;
+}
+
+.cancel-button-text {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 19px;
+  color: var(--primary-variant-color);
+}
+
+.cancel-button-text:hover {
+  opacity: 0.8;
+}
+
+.upload-button {
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  order: 1;
+  padding: 7px 20px;
+  background: var(--primary-color);
+  border-radius: 4px;
+}
+
+.upload-button:hover {
+  opacity: 0.8;
+}
+
+.upload-button-text {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 18px;
+  color: var(--white-color);
+}
+
+.upload-button-text:hover {
+  opacity: 0.8;
+}

--- a/src/components/Upload/UploadModal/ButtonGroup.module.css.d.ts
+++ b/src/components/Upload/UploadModal/ButtonGroup.module.css.d.ts
@@ -1,0 +1,8 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly 'cancel-button': string;
+  readonly 'cancel-button-text': string;
+  readonly 'upload-button': string;
+  readonly 'upload-button-text': string;
+};
+export = styles;

--- a/src/components/Upload/UploadModal/ButtonGroup.tsx
+++ b/src/components/Upload/UploadModal/ButtonGroup.tsx
@@ -1,86 +1,7 @@
 import type { FC } from 'react';
-import styled from 'styled-components';
-import { mixins } from '../../../styles';
 import type { Language } from '../../../types';
 import { assertNever } from '../../../utils';
-
-const _Wrapper = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 20px;
-  align-items: center;
-  justify-content: center;
-  order: 1;
-  padding: 0;
-`;
-
-const _CancelButton = styled.button`
-  box-sizing: border-box;
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: center;
-  justify-content: center;
-  order: 0;
-  padding: 12px 20px;
-  background: ${mixins.colors.background};
-  border: 1px solid ${mixins.colors.subText};
-  border-radius: 4px;
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-const _CancelButtonText = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 19px;
-  color: ${mixins.colors.primaryVariant};
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-const _UploadButton = styled.button`
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: center;
-  justify-content: center;
-  order: 1;
-  padding: 7px 20px;
-  background: ${mixins.colors.primary};
-  border-radius: 4px;
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-const _UploadButtonText = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 18px;
-  color: ${mixins.colors.white};
-  &:hover {
-    opacity: 0.8;
-  }
-`;
+import styles from './ButtonGroup.module.css';
 
 const cancelButtonText = (language: Language): string => {
   switch (language) {
@@ -115,12 +36,16 @@ export const ButtonGroup: FC<Props> = ({
   onClickUpload,
   onClickCancel,
 }) => (
-  <_Wrapper>
-    <_CancelButton onClick={onClickCancel}>
-      <_CancelButtonText>{cancelButtonText(language)}</_CancelButtonText>
-    </_CancelButton>
-    <_UploadButton onClick={onClickUpload}>
-      <_UploadButtonText>{uploadButtonText(language)}</_UploadButtonText>
-    </_UploadButton>
-  </_Wrapper>
+  <div className={styles.wrapper}>
+    <button onClick={onClickCancel} className={styles['cancel-button']}>
+      <div className={styles['cancel-button-text']}>
+        {cancelButtonText(language)}
+      </div>
+    </button>
+    <button onClick={onClickUpload} className={styles['upload-button']}>
+      <div className={styles['upload-button-text']}>
+        {uploadButtonText(language)}
+      </div>
+    </button>
+  </div>
 );

--- a/src/components/Upload/UploadModal/CreatedLgtmImage.module.css
+++ b/src/components/Upload/UploadModal/CreatedLgtmImage.module.css
@@ -1,0 +1,19 @@
+.wrapper {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+}
+
+.image {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: auto;
+  height: 270px;
+}
+
+@media (max-width: 767px) {
+  .image {
+    max-width: 355px;
+  }
+}

--- a/src/components/Upload/UploadModal/CreatedLgtmImage.module.css.d.ts
+++ b/src/components/Upload/UploadModal/CreatedLgtmImage.module.css.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly image: string;
+};
+export = styles;

--- a/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
+++ b/src/components/Upload/UploadModal/CreatedLgtmImage.tsx
@@ -1,27 +1,9 @@
 import type { FC } from 'react';
-import styled from 'styled-components';
 import { defaultAppUrl, type AppUrl } from '../../../constants';
 import { useClipboardMarkdown, useCopySuccess } from '../../../hooks';
-import { mixins } from '../../../styles';
 import { type LgtmImageUrl } from '../../../types';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
-
-const _Wrapper = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-`;
-
-const _Image = styled.img`
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    max-width: 355px;
-  }
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: auto;
-  height: 270px;
-`;
+import styles from './CreatedLgtmImage.module.css';
 
 type Props = {
   imagePreviewUrl: string;
@@ -46,9 +28,13 @@ export const CreatedLgtmImage: FC<Props> = ({
 
   return (
     <>
-      <_Wrapper ref={imageContextRef}>
-        <_Image src={imagePreviewUrl} />
-      </_Wrapper>
+      <div ref={imageContextRef} className={styles.wrapper}>
+        <img
+          src={imagePreviewUrl}
+          className={styles.image}
+          alt="Uploaded cat"
+        />
+      </div>
       {copied ? <CopiedGithubMarkdownMessage /> : ''}
     </>
   );

--- a/src/components/Upload/UploadModal/SuccessMessageArea.module.css
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.module.css
@@ -1,0 +1,164 @@
+.wrapper {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  flex-grow: 0;
+  gap: 24px;
+  align-items: center;
+  order: 1;
+  width: 399px;
+  height: 261px;
+  padding: 0;
+}
+
+.title {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 244px;
+  height: 28px;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 28px;
+  color: var(--primary-color);
+}
+
+.contents-wrapper {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  flex-grow: 0;
+  gap: 4px;
+  align-items: center;
+  order: 1;
+  width: 399px;
+  height: 209px;
+  padding: 0;
+}
+
+.main-message {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 332px;
+  height: 75px;
+  font-family: Roboto, sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 25px;
+  color: var(--sub-text-color);
+  text-align: center;
+}
+
+.under-section-wrapper {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  flex-grow: 0;
+  gap: 30px;
+  align-items: center;
+  order: 1;
+  width: 399px;
+  height: 130px;
+  padding: 0;
+}
+
+.description-wrapper {
+  box-sizing: border-box;
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: flex-start;
+  justify-content: center;
+  order: 0;
+  width: 399px;
+  height: 57px;
+  padding: 9px 20px 8px;
+  border: 1px solid var(--sub-color);
+  border-radius: 3px;
+}
+
+.description-text {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: 359px;
+  height: 40px;
+  font-family: Roboto, sans-serif;
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
+  color: var(--sub-text-color);
+}
+
+.button-group {
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+  order: 1;
+  padding: 0;
+}
+
+.close-button {
+  box-sizing: border-box;
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  order: 0;
+  padding: 12px 20px;
+  background: var(--background-color);
+  border: 1px solid var(--sub-text-color);
+  border-radius: 4px;
+}
+
+.close-button-text {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 19px;
+  color: var(--primary-variant-color);
+}
+
+.markdown-source-copy-button {
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-grow: 0;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  order: 1;
+  padding: 7px 20px;
+  background: var(--primary-color);
+  border-radius: 4px;
+}
+
+.markdown-source-copy-button-text {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 18px;
+  color: var(--white-color);
+}

--- a/src/components/Upload/UploadModal/SuccessMessageArea.module.css.d.ts
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.module.css.d.ts
@@ -1,0 +1,15 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly title: string;
+  readonly 'contents-wrapper': string;
+  readonly 'main-message': string;
+  readonly 'under-section-wrapper': string;
+  readonly 'description-wrapper': string;
+  readonly 'description-text': string;
+  readonly 'button-group': string;
+  readonly 'close-button': string;
+  readonly 'close-button-text': string;
+  readonly 'markdown-source-copy-button': string;
+  readonly 'markdown-source-copy-button-text': string;
+};
+export = styles;

--- a/src/components/Upload/UploadModal/SuccessMessageArea.tsx
+++ b/src/components/Upload/UploadModal/SuccessMessageArea.tsx
@@ -1,176 +1,10 @@
 import type { FC } from 'react';
-import styled from 'styled-components';
 import { defaultAppUrl, type AppUrl } from '../../../constants';
 import { useClipboardMarkdown, useCopySuccess } from '../../../hooks';
-import { mixins } from '../../../styles';
 import type { Language, LgtmImageUrl } from '../../../types';
 import { assertNever } from '../../../utils';
 import { CopiedGithubMarkdownMessage } from '../../LgtmImages/CopiedGithubMarkdownMessage';
-
-const _Wrapper = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: column;
-  flex-grow: 0;
-  gap: 24px;
-  align-items: center;
-  order: 1;
-  width: 399px;
-  height: 261px;
-  padding: 0;
-`;
-
-const _Title = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: 244px;
-  height: 28px;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 28px;
-  color: ${mixins.colors.primary};
-`;
-
-const _ContentsWrapper = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: column;
-  flex-grow: 0;
-  gap: 4px;
-  align-items: center;
-  order: 1;
-  width: 399px;
-  height: 209px;
-  padding: 0;
-`;
-
-const _MainMessage = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: 332px;
-  height: 75px;
-  font-family: Roboto, sans-serif;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 25px;
-  color: ${mixins.colors.subText};
-  text-align: center;
-`;
-
-const _UnderSectionWrapper = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: column;
-  flex-grow: 0;
-  gap: 30px;
-  align-items: center;
-  order: 1;
-  width: 399px;
-  height: 130px;
-  padding: 0;
-`;
-
-const _DescriptionWrapper = styled.div`
-  box-sizing: border-box;
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: flex-start;
-  justify-content: center;
-  order: 0;
-  width: 399px;
-  height: 57px;
-  padding: 9px 20px 8px;
-  border: 1px solid ${mixins.colors.sub};
-  border-radius: 3px;
-`;
-
-const _DescriptionText = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: 359px;
-  height: 40px;
-  font-family: Roboto, sans-serif;
-  font-size: 11px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 20px;
-  color: ${mixins.colors.subText};
-`;
-
-const _ButtonGroup = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 20px;
-  align-items: center;
-  justify-content: center;
-  order: 1;
-  padding: 0;
-`;
-
-const _CloseButton = styled.button`
-  box-sizing: border-box;
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: center;
-  justify-content: center;
-  order: 0;
-  padding: 12px 20px;
-  background: ${mixins.colors.background};
-  border: 1px solid ${mixins.colors.subText};
-  border-radius: 4px;
-`;
-
-const _CloseButtonText = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 19px;
-  color: ${mixins.colors.primaryVariant};
-`;
-
-const _MarkdownSourceCopyButton = styled.button`
-  display: flex;
-  flex: none;
-  flex-direction: row;
-  flex-grow: 0;
-  gap: 10px;
-  align-items: center;
-  justify-content: center;
-  order: 1;
-  padding: 7px 20px;
-  background: ${mixins.colors.primary};
-  border-radius: 4px;
-`;
-
-const _MarkdownSourceCopyButtonText = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 18px;
-  color: ${mixins.colors.white};
-`;
+import styles from './SuccessMessageArea.module.css';
 
 const titleText = (language: Language): string => {
   switch (language) {
@@ -255,27 +89,36 @@ export const SuccessMessageArea: FC<Props> = ({
   });
 
   return (
-    <_Wrapper>
-      <_Title>{titleText(language)}</_Title>
-      <_ContentsWrapper>
-        <_MainMessage>{mainMessageText(language)}</_MainMessage>
-        <_UnderSectionWrapper>
-          <_DescriptionWrapper>
-            <_DescriptionText>{descriptionText(language)}</_DescriptionText>
-          </_DescriptionWrapper>
-          <_ButtonGroup>
-            <_CloseButton onClick={onClickClose}>
-              <_CloseButtonText>{closeButtonText(language)}</_CloseButtonText>
-            </_CloseButton>
-            <_MarkdownSourceCopyButton ref={imageContextRef}>
-              <_MarkdownSourceCopyButtonText>
+    <div className={styles.wrapper}>
+      <div className={styles.title}>{titleText(language)}</div>
+      <div className={styles['contents-wrapper']}>
+        <div className={styles['main-message']}>
+          {mainMessageText(language)}
+        </div>
+        <div className={styles['under-section-wrapper']}>
+          <div className={styles['description-wrapper']}>
+            <div className={styles['description-text']}>
+              {descriptionText(language)}
+            </div>
+          </div>
+          <div className={styles['button-group']}>
+            <button className={styles['close-button']} onClick={onClickClose}>
+              <div className={styles['close-button-text']}>
+                {closeButtonText(language)}
+              </div>
+            </button>
+            <button
+              className={styles['markdown-source-copy-button']}
+              ref={imageContextRef}
+            >
+              <div className={styles['markdown-source-copy-button-text']}>
                 {markdownSourceCopyButtonText(language)}
-              </_MarkdownSourceCopyButtonText>
-            </_MarkdownSourceCopyButton>
-          </_ButtonGroup>
-        </_UnderSectionWrapper>
+              </div>
+            </button>
+          </div>
+        </div>
         {copied ? <CopiedGithubMarkdownMessage /> : ''}
-      </_ContentsWrapper>
-    </_Wrapper>
+      </div>
+    </div>
   );
 };

--- a/src/components/Upload/UploadModal/UploadModal.module.css
+++ b/src/components/Upload/UploadModal/UploadModal.module.css
@@ -1,0 +1,85 @@
+.wrapper {
+  position: absolute;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  width: 500px;
+  padding: 27px 30px 45px;
+  background: var(--background-color);
+  border: 1px dashed var(--sub-text-color);
+}
+
+@media (max-width: 767px) {
+  .wrapper {
+    width: 360px;
+  }
+}
+
+.contents-wrapper {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  flex-grow: 0;
+  gap: 14px;
+  align-items: center;
+  order: 0;
+  padding: 0;
+}
+
+.title {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  font-family: Roboto, sans-serif;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 28px;
+  color: var(--sub-text-color);
+  text-align: center;
+}
+
+.form-wrapper {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  flex-grow: 0;
+  gap: 16px;
+  align-items: center;
+  order: 1;
+  padding: 0;
+}
+
+.preview-image-wrapper {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+}
+
+.preview-image {
+  flex: none;
+  flex-grow: 0;
+  order: 0;
+  width: auto;
+  height: 270px;
+}
+
+@media (max-width: 767px) {
+  .preview-image {
+    max-width: 355px;
+  }
+}
+
+.confirm-message {
+  flex: none;
+  flex-grow: 0;
+  order: 1;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 22px;
+  color: var(--sub-text-color);
+}

--- a/src/components/Upload/UploadModal/UploadModal.module.css.d.ts
+++ b/src/components/Upload/UploadModal/UploadModal.module.css.d.ts
@@ -1,0 +1,10 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly 'contents-wrapper': string;
+  readonly title: string;
+  readonly 'form-wrapper': string;
+  readonly 'preview-image-wrapper': string;
+  readonly 'preview-image': string;
+  readonly 'confirm-message': string;
+};
+export = styles;

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -1,15 +1,13 @@
 import type { FC } from 'react';
 import Modal from 'react-modal';
-import styled from 'styled-components';
-
 import type { AppUrl } from '../../../constants';
-import { mixins } from '../../../styles';
 import type { Language, LgtmImageUrl } from '../../../types';
 import { assertNever } from '../../../utils';
 import { UploadProgressBar } from '../UploadProgressBar';
 import { ButtonGroup } from './ButtonGroup';
 import { CreatedLgtmImage } from './CreatedLgtmImage';
 import { SuccessMessageArea } from './SuccessMessageArea';
+import styles from './UploadModal.module.css';
 
 export type Props = {
   isOpen: boolean;
@@ -25,86 +23,6 @@ export type Props = {
   onClickMarkdownSourceCopyButton?: () => void;
   appUrl?: AppUrl;
 };
-
-const _Wrapper = styled.div`
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    width: 360px;
-  }
-  position: absolute;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  align-items: center;
-  width: 500px;
-  padding: 27px 30px 45px;
-  background: ${mixins.colors.background};
-  border: 1px dashed ${mixins.colors.subText};
-`;
-
-const _ContentsWrapper = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: column;
-  flex-grow: 0;
-  gap: 14px;
-  align-items: center;
-  order: 0;
-  padding: 0;
-`;
-
-const _Title = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  font-family: Roboto, sans-serif;
-  font-size: 18px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 28px;
-  color: ${mixins.colors.subText};
-  text-align: center;
-`;
-
-const _FormWrapper = styled.div`
-  display: flex;
-  flex: none;
-  flex-direction: column;
-  flex-grow: 0;
-  gap: 16px;
-  align-items: center;
-  order: 1;
-  padding: 0;
-`;
-
-const _PreviewImageWrapper = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-`;
-
-const _PreviewImage = styled.img`
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    max-width: 355px;
-  }
-  flex: none;
-  flex-grow: 0;
-  order: 0;
-  width: auto;
-  height: 270px;
-`;
-
-const _ConfirmMessage = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 1;
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 22px;
-  color: ${mixins.colors.subText};
-`;
 
 const titleText = (language: Language): string => {
   switch (language) {
@@ -128,7 +46,7 @@ const confirmMessageText = (language: Language): string => {
   }
 };
 
-const mediaQuery = `@media (maxWidth: ${mixins.mediaQuerySize.default})`;
+const mediaQuery = '@media (maxWidth: 767px)';
 
 const modalStyle = {
   // stylelint-disable-next-line
@@ -175,10 +93,10 @@ export const UploadModal: FC<Props> = ({
       style={modalStyle}
       onRequestClose={onClickCancel}
     >
-      <_Wrapper>
-        <_ContentsWrapper>
-          <_Title>{titleText(language)}</_Title>
-          <_FormWrapper>
+      <div className={styles.wrapper}>
+        <div className={styles['contents-wrapper']}>
+          <div className={styles.title}>{titleText(language)}</div>
+          <div className={styles['form-wrapper']}>
             {uploaded ? (
               <CreatedLgtmImage
                 imagePreviewUrl={imagePreviewUrl}
@@ -187,20 +105,24 @@ export const UploadModal: FC<Props> = ({
                 appUrl={appUrl}
               />
             ) : (
-              <_PreviewImageWrapper>
-                <_PreviewImage src={imagePreviewUrl} />
-              </_PreviewImageWrapper>
+              <div className={styles['preview-image-wrapper']}>
+                <img
+                  className={styles['preview-image']}
+                  src={imagePreviewUrl}
+                  alt="cat preview"
+                />
+              </div>
             )}
             {!isLoading && !uploaded ? (
               <>
-                <_ConfirmMessage>
+                <div className={styles['confirm-message']}>
                   {confirmMessageText(language)}
-                </_ConfirmMessage>
+                </div>
               </>
             ) : (
               ''
             )}
-          </_FormWrapper>
+          </div>
           {uploaded && createdLgtmImageUrl && !isLoading ? (
             <SuccessMessageArea
               language={language}
@@ -222,8 +144,8 @@ export const UploadModal: FC<Props> = ({
             ''
           )}
           {isLoading ? <UploadProgressBar language={language} /> : ''}
-        </_ContentsWrapper>
-      </_Wrapper>
+        </div>
+      </div>
     </Modal>
   );
 };

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.module.css
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.module.css
@@ -1,0 +1,37 @@
+.wrapper {
+  flex: none;
+  flex-grow: 0;
+  order: 1;
+  width: 280px;
+  height: 54px;
+}
+
+.bar-wrapper {
+  width: 280px;
+  height: 20px;
+}
+
+.main-color-bar {
+  width: 92px;
+  height: 18px;
+  background: var(--primary-variant-color);
+}
+
+.default-color-bar {
+  box-sizing: border-box;
+  width: 280px;
+  height: 20px;
+  background: var(--sub-color);
+  border: 1px solid var(--sub-text-color);
+}
+
+.message {
+  width: 56px;
+  height: 28px;
+  font-family: Roboto, sans-serif;
+  font-size: 15px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 28px;
+  color: var(--sub-text-color);
+}

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.module.css.d.ts
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.module.css.d.ts
@@ -1,0 +1,8 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly 'bar-wrapper': string;
+  readonly 'main-color-bar': string;
+  readonly 'default-color-bar': string;
+  readonly message: string;
+};
+export = styles;

--- a/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
+++ b/src/components/Upload/UploadProgressBar/UploadProgressBar.tsx
@@ -1,46 +1,7 @@
 import { useState, useEffect, type FC } from 'react';
-import styled from 'styled-components';
-import { mixins } from '../../../styles/mixins';
 import type { Language } from '../../../types';
 import { assertNever } from '../../../utils';
-
-const _Wrapper = styled.div`
-  flex: none;
-  flex-grow: 0;
-  order: 1;
-  width: 280px;
-  height: 54px;
-`;
-
-const _BarWrapper = styled.div`
-  width: 280px;
-  height: 20px;
-`;
-
-const _MainColorBar = styled.div`
-  width: 92px;
-  height: 18px;
-  background: ${mixins.colors.primaryVariant};
-`;
-
-const _DefaultColorBar = styled.div`
-  box-sizing: border-box;
-  width: 280px;
-  height: 20px;
-  background: ${mixins.colors.sub};
-  border: 1px solid ${mixins.colors.subText};
-`;
-
-const _Message = styled.p`
-  width: 56px;
-  height: 28px;
-  font-family: Roboto, sans-serif;
-  font-size: 15px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 28px;
-  color: ${mixins.colors.subText};
-`;
+import styles from './UploadProgressBar.module.css';
 
 const messageText = (language: Language): string => {
   switch (language) {
@@ -82,13 +43,16 @@ export const UploadProgressBar: FC<Props> = ({ language }) => {
   }, [progressLength]);
 
   return (
-    <_Wrapper>
-      <_BarWrapper>
-        <_DefaultColorBar>
-          <_MainColorBar style={{ width: `${progressLength}px` }} />
-        </_DefaultColorBar>
-      </_BarWrapper>
-      <_Message>{messageText(language)}</_Message>
-    </_Wrapper>
+    <div className={styles.wrapper}>
+      <div className={styles['bar-wrapper']}>
+        <div className={styles['default-color-bar']}>
+          <div
+            className={styles['main-color-bar']}
+            style={{ width: `${progressLength}px` }}
+          />
+        </div>
+      </div>
+      <p className={styles.message}>{messageText(language)}</p>
+    </div>
   );
 };

--- a/src/components/Upload/UploadTitleArea/UploadTitleArea.module.css
+++ b/src/components/Upload/UploadTitleArea/UploadTitleArea.module.css
@@ -1,0 +1,8 @@
+.wrapper {
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 28px;
+  color: var(--text-color);
+}

--- a/src/components/Upload/UploadTitleArea/UploadTitleArea.module.css.d.ts
+++ b/src/components/Upload/UploadTitleArea/UploadTitleArea.module.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+  readonly wrapper: string;
+};
+export = styles;

--- a/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
+++ b/src/components/Upload/UploadTitleArea/UploadTitleArea.tsx
@@ -1,17 +1,7 @@
 import type { FC } from 'react';
-import styled from 'styled-components';
-import { mixins } from '../../../styles';
 import { type Language } from '../../../types';
 import { assertNever } from '../../../utils';
-
-const _Wrapper = styled.div`
-  font-family: Roboto, sans-serif;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 28px;
-  color: ${mixins.colors.text};
-`;
+import styles from './UploadTitleArea.module.css';
 
 type Props = {
   language: Language;
@@ -33,5 +23,5 @@ const text = (language: Language): Text => {
 };
 
 export const UploadTitleArea: FC<Props> = ({ language }) => (
-  <_Wrapper>{text(language)}</_Wrapper>
+  <div className={styles.wrapper}>{text(language)}</div>
 );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/289

# Done の定義

- UploadForm 以外のUpload関連ComponentがCSS Modulesに置き換わっている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-fsiqegerzy.chromatic.com/?path=/story/templates-uploadtemplate--view-in-japanese

# 変更点概要

タイトルの通り。UploadForm は変更点が大きいので念の為、別PRにする。

今のところデザイン崩れは置きていない事を確認済。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし