### PR TITLE
UploadForm を CSS Modules に置換え

### DIFF
--- a/src/components/Upload/UploadForm/UploadForm.module.css
+++ b/src/components/Upload/UploadForm/UploadForm.module.css
@@ -1,7 +1,4 @@
-import styled from 'styled-components';
-import { mixins } from '../../../styles';
-
-export const _Wrapper = styled.div`
+.wrapper {
   display: flex;
   flex: none;
   flex-direction: column;
@@ -10,41 +7,44 @@ export const _Wrapper = styled.div`
   align-items: center;
   order: 0;
   padding: 0;
-`;
+}
 
-export const _Form = styled.form`
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    width: 380px;
-  }
+.form {
   flex: none;
   flex-grow: 0;
   order: 1;
   width: 500px;
-`;
+}
 
-export const _InputFileArea = styled.div`
+@media (max-width: 767px) {
+  .form {
+    width: 380px;
+  }
+}
+
+.input-file-area {
   box-sizing: border-box;
   display: grid;
   height: 220px;
-  background: ${mixins.colors.white};
-  border: 1px dashed ${mixins.colors.text};
-`;
+  background: var(--white-color);
+  border: 1px dashed var(--text-color);
+}
 
-export const _Text = styled.div`
+.text {
   font-family: Roboto, sans-serif;
   font-size: 16px;
   font-style: normal;
   font-weight: 700;
   line-height: 28px;
-  color: ${mixins.colors.subText};
+  color: var(--sub-text-color);
   text-align: center;
-`;
+}
 
-export const _InputFile = styled.input`
+.input-file {
   display: none;
-`;
+}
 
-export const _InputFileLabel = styled.label`
+.input-file-label {
   inset: 0;
   box-sizing: border-box;
   display: flex;
@@ -56,12 +56,12 @@ export const _InputFileLabel = styled.label`
   padding: 12px 20px;
   margin: auto;
   cursor: pointer;
-  background: ${mixins.colors.background};
-  border: 1px solid ${mixins.colors.subText};
+  background: var(--background-color);
+  border: 1px solid var(--sub-text-color);
   border-radius: 4px;
-`;
+}
 
-export const _InputFileLabelText = styled.div`
+.input-file-label-text {
   flex: none;
   flex-grow: 0;
   order: 0;
@@ -72,32 +72,32 @@ export const _InputFileLabelText = styled.div`
   font-style: normal;
   font-weight: 700;
   line-height: 19px;
-  color: ${mixins.colors.primaryVariant};
-`;
+  color: var(--primary-variant-color);
+}
 
-export const _MaxUploadSizeText = styled.div`
+.max-upload-size-text {
   height: 28px;
   font-family: Roboto, sans-serif;
   font-size: 13px;
   font-style: normal;
   font-weight: 400;
   line-height: 28px;
-  color: ${mixins.colors.subText};
+  color: var(--sub-text-color);
   text-align: right;
-`;
+}
 
-export const _CautionTextArea = styled.div`
+.caution-text-area {
   height: 28px;
   font-family: Roboto, sans-serif;
   font-size: 14px;
   font-style: normal;
   font-weight: 400;
   line-height: 28px;
-  color: ${mixins.colors.text};
+  color: var(--text-color);
   text-align: center;
-`;
+}
 
-export const _Notes = styled.div`
+.notes {
   top: 609px;
   height: 96px;
   font-family: Roboto, sans-serif;
@@ -105,40 +105,53 @@ export const _Notes = styled.div`
   font-style: normal;
   font-weight: 400;
   line-height: 24px;
-  color: ${mixins.colors.text};
-`;
+  color: var(--text-color);
+}
 
-export const _DescriptionAreaWrapper = styled.div`
+.description-area-wrapper {
   display: grid;
   gap: 24px;
-`;
+}
 
-export const _PrivacyPolicyArea = styled.div`
+.privacy-policy-area {
   height: 42px;
   font-family: Roboto, sans-serif;
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
   line-height: 21px;
-  color: ${mixins.colors.text};
+  color: var(--text-color);
   text-align: center;
-`;
+}
 
-export const _PrivacyLinkText = styled.span`
+.privacy-link-text {
   height: 42px;
   font-family: Roboto, sans-serif;
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
   line-height: 21px;
-  color: ${mixins.colors.primary};
+  color: var(--primary-color);
   text-align: center;
   text-decoration-line: underline;
   cursor: pointer;
-`;
+}
 
-export const _UploadButtonWrapper = styled.div`
+.upload-button-wrapper {
   display: flex;
   align-items: center;
   justify-content: center;
-`;
+}
+
+.fa-cloud-upload-alt {
+  font-style: normal;
+  font-weight: 900;
+  font-size: 42px;
+  line-height: 39px;
+  color: var(--primary-variant-color);
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+}

--- a/src/components/Upload/UploadForm/UploadForm.module.css.d.ts
+++ b/src/components/Upload/UploadForm/UploadForm.module.css.d.ts
@@ -1,0 +1,18 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly form: string;
+  readonly 'input-file-area': string;
+  readonly text: string;
+  readonly 'input-file': string;
+  readonly 'input-file-label': string;
+  readonly 'input-file-label-text': string;
+  readonly 'max-upload-size-text': string;
+  readonly 'caution-text-area': string;
+  readonly notes: string;
+  readonly 'description-area-wrapper': string;
+  readonly 'privacy-policy-area': string;
+  readonly 'privacy-link-text': string;
+  readonly 'upload-button-wrapper': string;
+  readonly 'fa-cloud-upload-alt': string;
+};
+export = styles;

--- a/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/src/components/Upload/UploadForm/UploadForm.tsx
@@ -16,7 +16,6 @@ import {
   createPrivacyPolicyLinksFromLanguages,
 } from '../../../features';
 import { isAcceptableFileSize } from '../../../features/lgtmImage';
-import { mixins } from '../../../styles';
 import type {
   AcceptedTypesImageExtension,
   ImageUploader,
@@ -31,22 +30,6 @@ import { UploadModal } from '../UploadModal';
 import { UploadTitleArea } from '../UploadTitleArea';
 
 import {
-  _CautionTextArea,
-  _DescriptionAreaWrapper,
-  _Form,
-  _InputFile,
-  _InputFileArea,
-  _InputFileLabel,
-  _InputFileLabelText,
-  _MaxUploadSizeText,
-  _Notes,
-  _PrivacyLinkText,
-  _PrivacyPolicyArea,
-  _Text,
-  _UploadButtonWrapper,
-  _Wrapper,
-} from './StyledComponents';
-import {
   cautionText,
   createImageSizeTooLargeErrorMessage,
   createNotAllowedImageExtensionErrorMessage,
@@ -55,19 +38,7 @@ import {
   unexpectedErrorMessage,
   uploadInputButtonText,
 } from './i18n';
-
-const faCloudUploadAltStyle = {
-  fontStyle: 'normal',
-  fontWeight: 900,
-  fontSize: '42px',
-  lineHeight: '39px',
-  color: `${mixins.colors.primaryVariant}`,
-  top: 0,
-  bottom: 0,
-  left: 0,
-  right: 0,
-  margin: 'auto',
-};
+import styles from './UploadForm.module.css';
 
 export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
   const privacyLinkAttribute = createPrivacyPolicyLinksFromLanguages(language);
@@ -75,23 +46,27 @@ export const createPrivacyPolicyArea = (language: Language): JSX.Element => {
   switch (language) {
     case 'ja':
       return (
-        <_PrivacyPolicyArea>
+        <div className={styles['privacy-policy-area']}>
           アップロードするボタンを押下することで{' '}
           <Link href={privacyLinkAttribute.link} prefetch={false}>
-            <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
+            <span className={styles['privacy-link-text']}>
+              {privacyLinkAttribute.text}
+            </span>
           </Link>{' '}
           に同意したと見なします
-        </_PrivacyPolicyArea>
+        </div>
       );
     case 'en':
       return (
-        <_PrivacyPolicyArea>
+        <div className={styles['privacy-policy-area']}>
           By pressing the upload button, you agree to the{' '}
           <Link href={privacyLinkAttribute.link} prefetch={false}>
-            <_PrivacyLinkText>{privacyLinkAttribute.text}</_PrivacyLinkText>
+            <span className={styles['privacy-link-text']}>
+              {privacyLinkAttribute.text}
+            </span>
           </Link>{' '}
           .
-        </_PrivacyPolicyArea>
+        </div>
       );
     default:
       return assertNever(language);
@@ -298,7 +273,7 @@ export const UploadForm: FC<Props> = ({
   const { getRootProps } = useDropzone({ onDrop });
 
   return (
-    <_Wrapper>
+    <div className={styles.wrapper}>
       {/* eslint-disable no-magic-numbers */}
       {displayErrorMessages.length === 0 ? (
         ''
@@ -306,38 +281,44 @@ export const UploadForm: FC<Props> = ({
         <UploadErrorMessageArea messages={displayErrorMessages} />
       )}
       <UploadTitleArea language={language} />
-      <_Form>
+      <form className={styles.form}>
         {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-        <div {...getRootProps()}>
-          <_InputFileArea>
-            <FaCloudUploadAlt style={faCloudUploadAltStyle} />
-            <_Text>{imageDropAreaText(language)}</_Text>
-            <_InputFileLabel>
-              <_InputFileLabelText>
-                {uploadInputButtonText(language)}
-              </_InputFileLabelText>
-              <_InputFile type="file" onChange={handleFileUpload} />
-            </_InputFileLabel>
-          </_InputFileArea>
+        <div {...getRootProps()} className={styles['input-file-area']}>
+          <FaCloudUploadAlt className={styles['fa-cloud-upload-alt']} />
+          <div className={styles.text}>{imageDropAreaText(language)}</div>
+          <label className={styles['input-file-label']}>
+            <div className={styles['input-file-label-text']}>
+              {uploadInputButtonText(language)}
+            </div>
+            <input
+              type="file"
+              className={styles['input-file']}
+              onChange={handleFileUpload}
+            />
+          </label>
         </div>
-        <_MaxUploadSizeText>Maximum upload size is 4MB</_MaxUploadSizeText>
-        <_DescriptionAreaWrapper>
-          <_CautionTextArea>{cautionText(language)}</_CautionTextArea>
-          <_Notes>
+        <div className={styles['max-upload-size-text']}>
+          Maximum upload size is 4MB
+        </div>
+        <div className={styles['description-area-wrapper']}>
+          <div className={styles['caution-text-area']}>
+            {cautionText(language)}
+          </div>
+          <div className={styles.notes}>
             {noteList(language).map((note, index) => (
               <p key={index}>{note}</p>
             ))}
-          </_Notes>
+          </div>
           {createPrivacyPolicyArea(language)}
-        </_DescriptionAreaWrapper>
-        <_UploadButtonWrapper>
+        </div>
+        <div className={styles['upload-button-wrapper']}>
           <UploadButton
             language={language}
             disabled={shouldDisableButton()}
             onClick={onClickUploadButton}
           />
-        </_UploadButtonWrapper>
-      </_Form>
+        </div>
+      </form>
       {imagePreviewUrl || createdLgtmImageUrl ? (
         <UploadModal
           isOpen={modalIsOpen}
@@ -356,6 +337,6 @@ export const UploadForm: FC<Props> = ({
       ) : (
         ''
       )}
-    </_Wrapper>
+    </div>
   );
 };


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/289

# Done の定義

- `src/components/Upload/UploadForm/UploadForm.tsx` がCSS Modules に置き換わっている事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-deajwyxcab.chromatic.com/?path=/story/components-upload-uploadform--view-in-japanese

https://62729802bbcc7d004a663d4c-deajwyxcab.chromatic.com/?path=/story/templates-uploadtemplate--view-in-japanese

# 変更点概要

本プロジェクトで一番大きなComponentである `src/components/Upload/UploadForm/UploadForm.tsx` を CSS Modules に置換え。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

https://zenn.dev/link/comments/70eb2b59b01ed1 で置換え状況をログに残している。

結構Componentが大きくなってしまっており、リファクタリングの余地があるので https://github.com/nekochans/lgtm-cat-ui/issues/300 でリファクタリングを実施する。