### PR TITLE
LGTM画像用のComponentを CSS Modules に置換え

### DIFF
--- a/src/components/LgtmImages/CopiedGithubMarkdownMessage.module.css
+++ b/src/components/LgtmImages/CopiedGithubMarkdownMessage.module.css
@@ -1,0 +1,19 @@
+.base {
+  position: absolute;
+  left: 50%;
+  padding: 3%;
+  color: var(--white-color);
+  text-align: center;
+  background: rgba(0, 0, 0, 0.8);
+  border-radius: 30px;
+  transform: translate(-50%, 0);
+}
+
+.default {
+  bottom: 30%;
+}
+
+.upper {
+  top: 15%;
+  opacity: 0.5;
+}

--- a/src/components/LgtmImages/CopiedGithubMarkdownMessage.module.css.d.ts
+++ b/src/components/LgtmImages/CopiedGithubMarkdownMessage.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly base: string;
+  readonly default: string;
+  readonly upper: string;
+};
+export = styles;

--- a/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
+++ b/src/components/LgtmImages/CopiedGithubMarkdownMessage.tsx
@@ -1,28 +1,5 @@
 import type { FC } from 'react';
-import styled, { css } from 'styled-components';
-import { mixins } from '../../styles';
-
-const baseCss = css`
-  position: absolute;
-  left: 50%;
-  padding: 3%;
-  color: ${mixins.colors.white};
-  text-align: center;
-  background: rgba(0, 0, 0, 0.8);
-  border-radius: 30px;
-  transform: translate(-50%, 0);
-`;
-
-const _DefaultWrapper = styled.div`
-  ${baseCss};
-  bottom: 30%;
-`;
-
-const _UpperWrapper = styled.div`
-  ${baseCss};
-  top: 15%;
-  opacity: 0.5;
-`;
+import styles from './CopiedGithubMarkdownMessage.module.css';
 
 type Props = {
   position?: 'default' | 'upper';
@@ -36,9 +13,9 @@ export const CopiedGithubMarkdownMessage: FC<Props> = ({
   return (
     <>
       {position === 'default' ? (
-        <_DefaultWrapper>{text}</_DefaultWrapper>
+        <div className={`${styles.base} ${styles.default}`}>{text}</div>
       ) : (
-        <_UpperWrapper>{text}</_UpperWrapper>
+        <div className={`${styles.base} ${styles.upper}`}>{text}</div>
       )}
     </>
   );

--- a/src/components/LgtmImages/LgtmImageContent.module.css
+++ b/src/components/LgtmImages/LgtmImageContent.module.css
@@ -1,0 +1,9 @@
+.wrapper {
+  position: relative;
+  height: 300px;
+  cursor: pointer;
+}
+
+.wrapper:hover {
+  opacity: 0.7;
+}

--- a/src/components/LgtmImages/LgtmImageContent.module.css.d.ts
+++ b/src/components/LgtmImages/LgtmImageContent.module.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+  readonly wrapper: string;
+};
+export = styles;

--- a/src/components/LgtmImages/LgtmImageContent.tsx
+++ b/src/components/LgtmImages/LgtmImageContent.tsx
@@ -1,21 +1,10 @@
 import type { FC } from 'react';
 import Image from 'next/image';
-import styled from 'styled-components';
-
 import { type AppUrl, defaultAppUrl } from '../../constants';
 import { useClipboardMarkdown, useCopySuccess } from '../../hooks';
-
 import type { LgtmImage } from '../../types';
 import { CopiedGithubMarkdownMessage } from './CopiedGithubMarkdownMessage';
-
-const _Wrapper = styled.div`
-  position: relative;
-  height: 300px;
-  cursor: pointer;
-  &:hover {
-    opacity: 0.7;
-  }
-`;
+import styles from './LgtmImageContent.module.css';
 
 type Props = LgtmImage & {
   appUrl?: AppUrl;
@@ -37,7 +26,7 @@ export const LgtmImageContent: FC<Props> = ({
   });
 
   return (
-    <_Wrapper key={id} ref={imageContextRef}>
+    <div key={id} ref={imageContextRef} className={styles.wrapper}>
       <Image
         src={imageUrl}
         style={{ objectFit: 'contain' }}
@@ -47,6 +36,6 @@ export const LgtmImageContent: FC<Props> = ({
         priority={true}
       />
       {copied ? <CopiedGithubMarkdownMessage /> : ''}
-    </_Wrapper>
+    </div>
   );
 };


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/287

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/287 のDoneの定義を満たす実装が完了している事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-ghqnmvjiaz.chromatic.com/?path=/story/components-lgtmimages--default

# 変更点概要

タイトルの通り。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
