### PR TITLE
Template系のComponentをCSS Modulesに置き換え

### DIFF
--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.module.css
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.module.css
@@ -1,0 +1,27 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+}
+
+.children-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 750px;
+  font-family: Roboto, sans-serif;
+  font-size: 20px;
+  font-style: normal;
+  line-height: 25px;
+  text-align: left;
+  overflow-wrap: normal;
+  list-style-position: inside;
+}
+
+@media (max-width: 767px) {
+  .children-wrapper {
+    max-width: 380px;
+  }
+}

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.module.css.d.ts
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.module.css.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly 'children-wrapper': string;
+};
+export = styles;

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -1,5 +1,4 @@
 import type { FC, MouseEventHandler, ReactNode } from 'react';
-import styled from 'styled-components';
 import { LibraryBooks } from '../../components';
 import { MarkdownPageTitle } from '../../components/MarkdownPageTitle';
 import {
@@ -7,9 +6,9 @@ import {
   createTermsOfUseLinksFromLanguages,
 } from '../../features';
 import { ResponsiveLayout } from '../../layouts';
-import { mixins } from '../../styles';
 import type { Language } from '../../types';
 import { assertNever } from '../../utils';
+import styles from './TermsOrPrivacyTemplate.module.css';
 
 export type TemplateType = 'terms' | 'privacy';
 
@@ -23,31 +22,6 @@ const createTitle = (type: TemplateType, language: Language): string => {
       return assertNever(type);
   }
 };
-
-const _Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  align-items: center;
-  justify-content: center;
-`;
-
-const _ChildrenWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  max-width: 750px;
-  font-family: Roboto, sans-serif;
-  font-size: 20px;
-  font-style: normal;
-  line-height: 25px;
-  text-align: left;
-  overflow-wrap: normal;
-  list-style-position: inside;
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    max-width: 380px;
-  }
-`;
 
 type Props = {
   type: TemplateType;
@@ -79,11 +53,11 @@ export const TermsOrPrivacyTemplate: FC<Props> = ({
         onClickLanguageButton={onClickLanguageButton}
         currentUrlPath={currentUrlPath}
       >
-        <_Wrapper>
+        <div className={styles.wrapper}>
           <MarkdownPageTitle text={createTitle(type, language)} />
           <LibraryBooks />
-          <_ChildrenWrapper>{children}</_ChildrenWrapper>
-        </_Wrapper>
+          <div className={styles['children-wrapper']}>{children}</div>
+        </div>
       </ResponsiveLayout>
     </div>
   );

--- a/src/templates/TopTemplate/AppDescriptionArea.module.css
+++ b/src/templates/TopTemplate/AppDescriptionArea.module.css
@@ -1,0 +1,16 @@
+.text {
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 28px;
+  color: #43281e;
+  text-align: center;
+}
+
+.ja-text {
+  font-family: Zen Kaku Gothic New, sans-serif;
+}
+
+.en-text {
+  font-family: Roboto, sans-serif;
+}

--- a/src/templates/TopTemplate/AppDescriptionArea.module.css.d.ts
+++ b/src/templates/TopTemplate/AppDescriptionArea.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly text: string;
+  readonly 'ja-text': string;
+  readonly 'en-text': string;
+};
+export = styles;

--- a/src/templates/TopTemplate/AppDescriptionArea.tsx
+++ b/src/templates/TopTemplate/AppDescriptionArea.tsx
@@ -17,25 +17,25 @@ export type Props = {
 };
 
 const JaAppDescriptionArea: FC = () => (
-  <>
+  <div>
     <div className={`${styles.text} ${styles['ja-text']}`}>
       {jaUpperSectionText}
     </div>
     <div className={`${styles.text} ${styles['ja-text']}`}>
       {jaLowerSectionText}
     </div>
-  </>
+  </div>
 );
 
 const EnAppDescriptionArea: FC = () => (
-  <>
+  <div>
     <div className={`${styles.text} ${styles['en-text']}`}>
       {enUpperSectionText}
     </div>
     <div className={`${styles.text} ${styles['en-text']}`}>
       {enLowerSectionText}
     </div>
-  </>
+  </div>
 );
 
 export const AppDescriptionArea: FC<Props> = ({ language }) => {

--- a/src/templates/TopTemplate/AppDescriptionArea.tsx
+++ b/src/templates/TopTemplate/AppDescriptionArea.tsx
@@ -1,29 +1,7 @@
 import type { FC } from 'react';
-import styled, { css } from 'styled-components';
-
 import type { Language } from '../../types';
 import { assertNever } from '../../utils';
-
-const _Wrapper = styled.div``;
-
-const textStyle = css`
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 28px;
-  color: #43281e;
-  text-align: center;
-`;
-
-const _JaText = styled.div`
-  font-family: Zen Kaku Gothic New, sans-serif;
-  ${textStyle};
-`;
-
-const _EnText = styled.div`
-  font-family: Roboto, sans-serif;
-  ${textStyle};
-`;
+import styles from './AppDescriptionArea.module.css';
 
 const jaUpperSectionText = '猫のLGTM画像を共有出来るサービスです。';
 
@@ -39,17 +17,25 @@ export type Props = {
 };
 
 const JaAppDescriptionArea: FC = () => (
-  <_Wrapper>
-    <_JaText>{jaUpperSectionText}</_JaText>
-    <_JaText>{jaLowerSectionText}</_JaText>
-  </_Wrapper>
+  <>
+    <div className={`${styles.text} ${styles['ja-text']}`}>
+      {jaUpperSectionText}
+    </div>
+    <div className={`${styles.text} ${styles['ja-text']}`}>
+      {jaLowerSectionText}
+    </div>
+  </>
 );
 
 const EnAppDescriptionArea: FC = () => (
-  <_Wrapper>
-    <_EnText>{enUpperSectionText}</_EnText>
-    <_EnText>{enLowerSectionText}</_EnText>
-  </_Wrapper>
+  <>
+    <div className={`${styles.text} ${styles['en-text']}`}>
+      {enUpperSectionText}
+    </div>
+    <div className={`${styles.text} ${styles['en-text']}`}>
+      {enLowerSectionText}
+    </div>
+  </>
 );
 
 export const AppDescriptionArea: FC<Props> = ({ language }) => {

--- a/src/templates/TopTemplate/CatRandomCopyButtonWrapper.module.css
+++ b/src/templates/TopTemplate/CatRandomCopyButtonWrapper.module.css
@@ -1,0 +1,7 @@
+.wrapper {
+  display: grid;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}

--- a/src/templates/TopTemplate/CatRandomCopyButtonWrapper.module.css.d.ts
+++ b/src/templates/TopTemplate/CatRandomCopyButtonWrapper.module.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+  readonly wrapper: string;
+};
+export = styles;

--- a/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
+++ b/src/templates/TopTemplate/CatRandomCopyButtonWrapper.tsx
@@ -1,18 +1,9 @@
 import type { FC } from 'react';
-import styled from 'styled-components';
-
 import {
   CatRandomCopyButton,
   type CatRandomCopyButtonProps,
 } from '../../components';
-
-const _Wrapper = styled.div`
-  display: grid;
-  gap: 20px;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-`;
+import styles from './CatRandomCopyButtonWrapper.module.css';
 
 type Props = CatRandomCopyButtonProps;
 
@@ -21,11 +12,11 @@ export const CatRandomCopyButtonWrapper: FC<Props> = ({
   imageUrl,
   callback,
 }) => (
-  <_Wrapper>
+  <div className={styles.wrapper}>
     <CatRandomCopyButton
       appUrl={appUrl}
       imageUrl={imageUrl}
       callback={callback}
     />
-  </_Wrapper>
+  </div>
 );

--- a/src/templates/TopTemplate/LgtmImagesContents.module.css
+++ b/src/templates/TopTemplate/LgtmImagesContents.module.css
@@ -1,0 +1,6 @@
+.wrapper {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 100%;
+  gap: 32px;
+}

--- a/src/templates/TopTemplate/LgtmImagesContents.module.css.d.ts
+++ b/src/templates/TopTemplate/LgtmImagesContents.module.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+  readonly wrapper: string;
+};
+export = styles;

--- a/src/templates/TopTemplate/LgtmImagesContents.tsx
+++ b/src/templates/TopTemplate/LgtmImagesContents.tsx
@@ -1,5 +1,4 @@
 import type { FC, ReactNode } from 'react';
-import styled from 'styled-components';
 import { useSnapshot } from 'valtio';
 import { ErrorContent, LgtmImages } from '../../components';
 import { CatButtonGroup } from '../../components/Button';
@@ -9,13 +8,7 @@ import { lgtmImageStateSelector } from '../../stores';
 import type { Language, LgtmImage } from '../../types';
 import { AppDescriptionArea } from './AppDescriptionArea';
 import { CatRandomCopyButtonWrapper } from './CatRandomCopyButtonWrapper';
-
-const _Wrapper = styled.div`
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  grid-template-columns: 100%;
-  gap: 32px;
-`;
+import styles from './LgtmImagesContents.module.css';
 
 type Props = {
   language: Language;
@@ -52,7 +45,7 @@ export const LgtmImagesContents: FC<Props> = ({
     ];
 
   return (
-    <_Wrapper>
+    <div className={styles.wrapper}>
       <AppDescriptionArea language={language} />
       <CatRandomCopyButtonWrapper
         appUrl={appUrl}
@@ -77,6 +70,6 @@ export const LgtmImagesContents: FC<Props> = ({
           callback={clipboardMarkdownCallback}
         />
       )}
-    </_Wrapper>
+    </div>
   );
 };

--- a/src/templates/UploadTemplate/UploadTemplate.module.css
+++ b/src/templates/UploadTemplate/UploadTemplate.module.css
@@ -1,0 +1,11 @@
+.image-wrapper {
+  display: grid;
+  grid-template-columns: 302px 302px 302px;
+}
+
+@media (max-width: 767px) {
+  .image-wrapper {
+    grid-template-columns: 302px;
+    justify-content: center;
+  }
+}

--- a/src/templates/UploadTemplate/UploadTemplate.module.css.d.ts
+++ b/src/templates/UploadTemplate/UploadTemplate.module.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+  readonly 'image-wrapper': string;
+};
+export = styles;

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -1,20 +1,10 @@
 import type { FC, ReactNode } from 'react';
-import styled from 'styled-components';
 import { UploadForm } from '../../components';
 import { type AppUrl } from '../../constants';
 import { useSwitchLanguage } from '../../hooks';
 import { ResponsiveLayout } from '../../layouts';
-import { mixins } from '../../styles';
 import type { Language, ImageUploader, ImageValidator } from '../../types';
-
-const _ImageWrapper = styled.div`
-  display: grid;
-  grid-template-columns: 302px 302px 302px;
-  @media (max-width: ${mixins.mediaQuerySize.default}) {
-    grid-template-columns: 302px;
-    justify-content: center;
-  }
-`;
+import styles from './UploadTemplate.module.css';
 
 type Props = {
   language: Language;
@@ -57,7 +47,7 @@ export const UploadTemplate: FC<Props> = ({
           onClickMarkdownSourceCopyButton={onClickMarkdownSourceCopyButton}
           appUrl={appUrl}
         />
-        <_ImageWrapper>{catImage}</_ImageWrapper>
+        <div className={styles['image-wrapper']}>{catImage}</div>
       </ResponsiveLayout>
     </div>
   );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/291

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/291 のDoneの定義を満たす実装が完了している事

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-zwmwnivvri.chromatic.com/?path=/story/templates-toptemplate--view-in-japanese

# 変更点概要

タイトルの通り `src/templates/` 配下のComponentをCSS Modulesに置き換え。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし