### PR TITLE
ResponsiveLayoutをCSS Modulesに置換え

### DIFF
--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.module.css
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.module.css
@@ -1,0 +1,14 @@
+.wrapper {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 100%;
+  gap: 64px;
+  min-height: 100vh;
+}
+
+.contents-wrapper {
+  display: inline-block;
+  margin: 0 auto;
+  text-align: center;
+  vertical-align: middle;
+}

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.module.css.d.ts
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.module.css.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly wrapper: string;
+  readonly 'contents-wrapper': string;
+};
+export = styles;

--- a/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
+++ b/src/layouts/ResponsiveLayout/ResponsiveLayout.tsx
@@ -1,23 +1,7 @@
 import type { FC, ReactNode } from 'react';
-import styled from 'styled-components';
-
 import { Footer, type Props as FooterProps } from '../../components/Footer';
 import { Header, type Props as HeaderProps } from '../../components/Header';
-
-const _Wrapper = styled.div`
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  grid-template-columns: 100%;
-  gap: 64px;
-  min-height: 100vh;
-`;
-
-const _ContentsWrapper = styled.div`
-  display: inline-block;
-  margin: 0 auto;
-  text-align: center;
-  vertical-align: middle;
-`;
+import styles from './ResponsiveLayout.module.css';
 
 export type Props = FooterProps & HeaderProps & { children: ReactNode };
 
@@ -28,14 +12,14 @@ export const ResponsiveLayout: FC<Props> = ({
   currentUrlPath,
   children,
 }) => (
-  <_Wrapper>
+  <div className={styles.wrapper}>
     <Header
       language={language}
       isLanguageMenuDisplayed={isLanguageMenuDisplayed}
       onClickLanguageButton={onClickLanguageButton}
       currentUrlPath={currentUrlPath}
     />
-    <_ContentsWrapper>{children}</_ContentsWrapper>
+    <div className={styles['contents-wrapper']}>{children}</div>
     <Footer language={language} />
-  </_Wrapper>
+  </div>
 );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/290

# Done の定義

- https://github.com/nekochans/lgtm-cat-ui/issues/290 のDoneの定義を満たす実装が完了している事

# スクリーンショット or Storybook の URL

- https://62729802bbcc7d004a663d4c-mftrgwhnvs.chromatic.com/?path=/story/layouts-responsivelayout--view-in-japanese
- https://62729802bbcc7d004a663d4c-mftrgwhnvs.chromatic.com/?path=/story/layouts-responsivelayout--view-in-english

# 変更点概要

タイトルの通り `src/layouts/ResponsiveLayout/ResponsiveLayout.tsx` をCSS Modules に置換え。

これで全てのComponentが CSS Modules に置き換わった。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
