### PR TITLE
release/v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "2.4.4",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "2.4.4",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@storybook/addon-a11y": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "2.4.4",
+  "version": "3.0.0",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "./dist/index.es.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
https://github.com/nekochans/lgtm-cat/issues/26 の通りスタイリングを CSS Modulesにしたバージョンのrelease用PR。

UIの仕様は変わっていない。

しかし `styled-components` への依存がなくなり共通CSSのimportが必要になったのでメジャーバージョンアップとした。