### PR TITLE
tsconfig.jsonの設定をNext.jsのテンプレートに合わせて修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekochans/lgtm-cat-ui",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "https://lgtmeow.com のUIComponentを管理する為のpackage",
   "main": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
     "sourceMap": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "incremental": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,18 @@
 {
   "compilerOptions": {
-    "target": "es2016",
-    "module": "esnext",
-    "jsx": "react-jsxdev",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "sourceMap": true,
     "outDir": "dist",
-    "strict": true,
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "allowJs": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "declaration": true,
-    "declarationDir": "types",
-    "emitDeclarationOnly": true,
-    "isolatedModules": true
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
   }
 }


### PR DESCRIPTION
# issueURL

なし

# このPRで対応すること / このPRで対応しないこと

`tsconfig.json` の内容を最新のNext.jsのテンプレートに合わせて修正する。

# スクリーンショット or Storybook の URL

https://62729802bbcc7d004a663d4c-zvhlvvlxgx.chromatic.com/

# 変更点概要

タイトルの通り、最終的には `lgtm-cat-frontend` 側にComponentを移植するのでこちらはNext.jsに最適な形に変更する。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし